### PR TITLE
Close 0.4.0 pre-live certification release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 All notable project changes should be recorded here so the README and roadmap
 can stay focused on current usage and future direction.
 
-The source/package version is `0.4.0`. The release candidate is prepared for
-merged-tree verification; this changelog does not yet claim an annotated tag,
-PyPI publication, or hosted GitHub Release.
+The source/package version is `0.4.0`. The annotated `v0.4.0` tag identifies the
+reviewed closeout merge. No PyPI publication or hosted GitHub Release is
+claimed.
 
 ## Unreleased
 
@@ -40,9 +40,10 @@ No changes yet.
 - Reorganized documentation ownership: the README is now a concise user front
   door, architecture owns system structure, the roadmap contains only planned
   work, and `docs/README.md` routes each technical and research topic.
-- Completed the repository-owned implementation in the release-ready work
-  packet and narrowed the immediate roadmap to credentialed exact-run evidence
-  and predeclared recurrence; no credentialed run or readiness promotion is
+- Closed the repository-owned implementation work packet after contributor and
+  closeout pull requests, branch and merged-tree gates, and release tagging.
+  The immediate roadmap is now limited to credentialed exact-run evidence and
+  predeclared recurrence; no credentialed run or readiness promotion is
   claimed.
 - Databento subscription diagnostics now call SDK return values local request
   IDs rather than provider acknowledgements and use actual records/errors for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,9 +137,9 @@ changes before implementation, name a work packet for L2/L3 work, preserve its
 baseline and evidence ceiling, and close technical shipment separately from
 external outcome validation. Use a `codex/` feature branch, focused named-file
 commits, a pull request, hosted checks, merge, and a clean post-merge test for a
-release slice. The release-ready
-[GEX-LIVE-001 packet](docs/work-packets/GEX-LIVE-001.md) owns the `0.4.0`
-pre-live hardening slice through merged-tree and tag closeout. The earlier
+release slice. The closed
+[GEX-LIVE-001 packet](docs/work-packets/GEX-LIVE-001.md) records that complete
+workflow for the `0.4.0` pre-live hardening slice. The earlier
 [GEX-ORC-001 packet](docs/work-packets/GEX-ORC-001.md) remains a structural
 example. A new routed packet is required for any unrelated L2/L3 change. A
 credentialed certification run is external observation, not permission to

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ and limitations are documented in
 ## Current Status
 
 The source/package version is `0.4.0`, **Pre-Live Certification Hardening**.
-The release candidate is in contributor review; the annotated `v0.4.0` tag is
-created only after clean merged-tree verification. The project does not yet
-claim that tag, a PyPI publication, or a hosted release.
+The annotated `v0.4.0` tag identifies the reviewed closeout merge after clean
+branch and merged-tree verification. The release is not published to PyPI and
+does not have a hosted GitHub Release.
 
 Provider readiness is intentionally explicit:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,12 +19,10 @@ of every result.
 | Blocked | Build a governed real-session evaluation corpus | Licensed retention/research authority plus a certified provider path |
 | Later | Stabilize research interfaces and live delivery | Reproducible corpus/model evidence and demonstrated user need |
 
-The `0.4.0` release candidate implements the repository-owned pre-live
-hardening under the release-ready
-[GEX-LIVE-001 packet](docs/work-packets/GEX-LIVE-001.md). The packet remains
-active through merged-tree and tag closeout. Databento still has registry status
-`live-uncertified`: no credentialed report or recurring service evidence is
-claimed.
+Version `0.4.0` shipped the repository-owned pre-live hardening under the closed
+[GEX-LIVE-001 packet](docs/work-packets/GEX-LIVE-001.md). Databento still has
+registry status `live-uncertified`: no credentialed report or recurring service
+evidence is claimed.
 
 ## Now: Credentialed Databento Evidence
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,10 @@ API tokens, session tokens, or private market-data entitlement details.
 
 ## Supported Versions
 
-This project is pre-1.0. The supported source/package version is `0.4.0`; the
-annotated `v0.4.0` tag is created only after clean merged-tree verification.
-The release candidate does not yet claim that tag, a published PyPI artifact,
-or a hosted release. Security fixes target the latest `main` branch.
+This project is pre-1.0. The supported source/package version is `0.4.0`, and
+the annotated `v0.4.0` tag identifies its reviewed closeout merge. No published
+PyPI artifact or hosted GitHub Release is claimed. Security fixes target the
+latest `main` branch.
 
 ## Reporting a Vulnerability
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,7 @@ status checklists into multiple files.
 
 An active work packet under `work-packets/` owns the status of its authorized
 change. Closed packets are historical evidence and do not make a roadmap item
-active. `GEX-LIVE-001` remains active through the contributor merge,
-merged-tree verification, closeout pull request, and release tag.
+active. No work packet is active after the `0.4.0` release closeout.
 
 ## Start Here By Goal
 
@@ -83,9 +82,9 @@ merged-tree verification, closeout pull request, and release tag.
   contract-driven research identity decision.
 - [GEX-ORC-001](work-packets/GEX-ORC-001.md) — closed `0.3.0` work-packet record;
   it is not an active packet.
-- [GEX-LIVE-001](work-packets/GEX-LIVE-001.md) — release-ready `0.4.0` pre-live
-  hardening packet; merge/tag closeout is pending and credentialed validation
-  remains external follow-on work.
+- [GEX-LIVE-001](work-packets/GEX-LIVE-001.md) — closed `0.4.0` pre-live
+  hardening and release record; credentialed validation remains external
+  follow-on work.
 
 ## Editing Rules
 

--- a/docs/SAED_ADOPTION_PROFILE.md
+++ b/docs/SAED_ADOPTION_PROFILE.md
@@ -18,8 +18,8 @@
 
 **Adopted:** 2026-08-19
 
-**Status owner:** Active release-ready packet `GEX-LIVE-001` under
-`docs/work-packets/`
+**Status owner:** No active work packet; closed packet `GEX-LIVE-001` records
+the `0.4.0` repository release
 
 ## Purpose And Entry Boundary
 
@@ -155,4 +155,4 @@ predeclared outcomes, untouched test data, costs, and an observation window.
 | Date | From | To | Changed Rules | Active Packets | Decision |
 | --- | --- | --- | --- | --- | --- |
 | 2026-08-19 | none | `gex-terminal-team-v1` | Initial SAED 1.3 adoption | `GEX-ORC-001` | Adopted for multi-participant release workflow |
-| 2026-08-31 | `GEX-ORC-001` closed | `GEX-LIVE-001` release ready | Implemented repository-owned pre-live certification hardening for `0.4.0`; merged-tree closeout and credentialed outcome remain open | `GEX-LIVE-001` | Maintainer authorized; release closeout pending |
+| 2026-08-31 | `GEX-ORC-001` closed | `GEX-LIVE-001` closed | Shipped repository-owned pre-live certification hardening for `0.4.0`; credentialed outcome remains external | none | Contributor and closeout pull requests, merged-tree gate, and annotated tag completed |

--- a/docs/work-packets/GEX-LIVE-001.md
+++ b/docs/work-packets/GEX-LIVE-001.md
@@ -6,14 +6,18 @@ method_version: "1.3"
 profile: gex-terminal-team-v1
 adoption_context: team
 change_rigor: L3
-status: "Release Ready — implementation verified"
+status: "Closed — repository release shipped; external observation open"
 packet_owner: project maintainer
 spec_steward: implementation agent
 architecture_authority: project maintainer
 evidence_reviewer: pull-request reviewer and hosted CI
 baseline: main@360abdc
 branch: codex/gex-live-001-prelive-v0.4.0
+feature_pull_request: 14
+feature_merge: main@e58511cf652a5dcfe3326869987b6b9a8d34f890
+closeout_branch: codex/gex-live-001-prelive-v0.4.0-closeout
 target_release: "0.4.0 Pre-Live Certification Hardening"
+release_tag: v0.4.0
 created: 2026-08-31
 external_outcome: "Open — credentialed provider observation"
 ```
@@ -115,8 +119,8 @@ This packet adopts `INV-01` through `INV-08` from
 | `AC-03` | Diagnostics remain bounded to observed callbacks and do not claim real provider behavior or reinterpret request IDs as acknowledgements. | Evidence-ceiling assertions | Verified |
 | `REQ-06` | Logging level is configurable and report/log redaction covers secrets and sensitive identifiers recursively. | Redaction and CLI tests | Verified |
 | `REQ-07` | Capture governance rejects ambiguous rights/retention/redaction/research-use declarations and captured-session corpus mismatches. | Policy/corpus tests and guide | Verified |
-| `AC-04` | Full source, behavioral, offline-provider, research, performance, distribution, and documentation gates pass on branch and merged `main`. | Release evidence | Pending merged-tree closeout |
-| `AC-05` | Version, changelog, package metadata, merged commit, and annotated `v0.4.0` tag agree. | Release identity checks | Pending merged-tree closeout |
+| `AC-04` | Full source, behavioral, offline-provider, research, performance, distribution, and documentation gates pass on branch and merged `main`. | Release evidence | Verified |
+| `AC-05` | Version, changelog, package metadata, merged commit, and annotated `v0.4.0` tag agree. | Release identity checks | Verified at release closeout |
 
 ## Architecture Delta
 
@@ -178,8 +182,9 @@ release tree. No user data or licensed market data is migrated.
 
 ## Amendments
 
-None at baseline. Material scope, invariant, authority, proof-ceiling, version,
-or recovery changes must be appended before implementation continues.
+- 2026-08-31 — The evidence-only closeout records the reviewed feature merge,
+  clean merged-tree gates, narrow closeout pull request, and authorized release
+  tag. It changes no implementation scope, invariant, or evidence ceiling.
 
 ## Evidence
 
@@ -216,9 +221,21 @@ Repository evidence:
   property/fault/performance gates, experiment reproduction, batch comparison,
   and corpus registration/verification. Persisted outputs contained no checkout
   or site-packages paths.
-- The contributor branch implementation is release-ready. Its pull-request
-  merge, clean merged-tree gate, narrow closeout pull request, final merge, and
-  annotated `v0.4.0` tag remain the pending release-identity evidence.
+- Contributor pull request
+  [#14](https://github.com/zrack/gex-terminal/pull/14) passed its Python 3.11 and
+  3.12 hosted checks and merged with commit
+  `e58511cf652a5dcfe3326869987b6b9a8d34f890`, preserving the three contributor
+  commits. The original `main` checkout then fast-forwarded cleanly from
+  `origin/main` without modifying its pre-existing untracked image files.
+- The merged tree passed source compilation, patch hygiene, all 297 unit tests,
+  model evidence, offline Databento certification, 7/7 model properties, 7/7
+  provider faults, the 500-contract performance budget, documentation links,
+  screenshot export, isolated wheel/source build, and Twine validation. The
+  [hosted merged-main run](https://github.com/zrack/gex-terminal/actions/runs/33474249035)
+  also passed both supported Python versions.
+- The documentation-only closeout pull request records actual release evidence.
+  Its merge commit is the annotated `v0.4.0` target; the tag is pushed only after
+  that merge is re-read from clean `main` and its identity checks pass.
 
 External evidence remains deliberately absent. No credentialed Databento run,
 licensed OI observation, provider-side resubscription result, recurring service

--- a/docs/work-packets/GEX-LIVE-001.md
+++ b/docs/work-packets/GEX-LIVE-001.md
@@ -16,6 +16,7 @@ branch: codex/gex-live-001-prelive-v0.4.0
 feature_pull_request: 14
 feature_merge: main@e58511cf652a5dcfe3326869987b6b9a8d34f890
 closeout_branch: codex/gex-live-001-prelive-v0.4.0-closeout
+closeout_pull_request: 15
 target_release: "0.4.0 Pre-Live Certification Hardening"
 release_tag: v0.4.0
 created: 2026-08-31
@@ -233,9 +234,11 @@ Repository evidence:
   screenshot export, isolated wheel/source build, and Twine validation. The
   [hosted merged-main run](https://github.com/zrack/gex-terminal/actions/runs/33474249035)
   also passed both supported Python versions.
-- The documentation-only closeout pull request records actual release evidence.
-  Its merge commit is the annotated `v0.4.0` target; the tag is pushed only after
-  that merge is re-read from clean `main` and its identity checks pass.
+- Documentation-only closeout pull request
+  [#15](https://github.com/zrack/gex-terminal/pull/15) records actual release
+  evidence. Its merge commit is the annotated `v0.4.0` target; the tag is pushed
+  only after that merge is re-read from clean `main` and its identity checks
+  pass.
 
 External evidence remains deliberately absent. No credentialed Databento run,
 licensed OI observation, provider-side resubscription result, recurring service


### PR DESCRIPTION
## Summary

- record the reviewed feature merge and exact merged-main commit
- record local and hosted branch/merged-tree gates
- close the repository-owned work packet while keeping credentialed Databento validation explicitly external
- make the closeout merge the intended annotated `v0.4.0` tag target

## Verification

- documentation links and release metadata checks passed
- `git diff --check` passed
- merged `main` previously passed 297 tests, all offline evidence gates, the 500-contract performance gate, isolated build/Twine, and hosted Python 3.11/3.12 CI

This pull request changes documentation status and release evidence only; it does not change runtime code or claim live-provider certification.
