### PR TITLE
Update CI actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ claimed.
 
 ## Unreleased
 
-No changes yet.
+### Changed
+
+- Updated GitHub CI to the Node 24-based `actions/checkout@v7` and
+  `actions/setup-python@v7` releases after the hosted runner reported the older
+  Node 20 action runtimes as deprecated.
 
 ## 0.4.0 - 2026-08-31 — Pre-Live Certification Hardening
 


### PR DESCRIPTION
## Summary

- update `actions/checkout` and `actions/setup-python` to their official v7 releases
- remove the Node 20 action-runtime deprecation warnings observed in the successful `v0.4.0` tag workflow
- record the post-release maintenance change under Unreleased

## Verification

- `git diff --check` passed
- all 14 release-contract tests passed
- official latest releases are `actions/checkout` v7.0.1 and `actions/setup-python` v7.0.0; the workflow uses no removed setup-python v7 inputs

This does not move or alter the immutable `v0.4.0` tag.
