### PR TITLE
Map the competitive landscape and product roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ claimed.
 
 ### Changed
 
+- Refreshed the September 2026 competitive landscape with Nightglass,
+  GammaTape, FlashAlpha, current industry evidence, a narrower native-futures
+  positioning, and a gated path from research kernel to commercial product.
+- Expanded the product vision and roadmap around a bring-your-own-data desktop
+  hypothesis, a comparable hosted-cockpit alternative, customer validation,
+  distributable offline workflows, bounded live certification, design-partner
+  evidence, governed outcome research, and commercial exit criteria.
 - Updated GitHub CI to the Node 24-based `actions/checkout@v7` and
   `actions/setup-python@v7` releases after the hosted runner reported the older
   Node 20 action runtimes as deprecated.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,91 +2,504 @@
 
 This file contains planned and deferred work only. Shipped work belongs in
 [CHANGELOG.md](CHANGELOG.md), the current system belongs in
-[docs/architecture.md](docs/architecture.md), and durable product outcomes
-belong in [docs/product-vision.md](docs/product-vision.md).
+[Architecture](docs/architecture.md), durable outcomes belong in
+[Product Vision](docs/product-vision.md), and the evidence behind the strategy
+belongs in [Competitive Landscape](docs/market-analysis.md).
 
-The project direction remains an evidence-bounded, local-first GEX model
-laboratory: normalize provider inputs, preserve position-model provenance,
-compare methods on identical point-in-time sessions, and state the proof ceiling
-of every result.
+## Product Destination
 
-## Priority Order
+Build the auditable, local-first ES/NQ market-structure instrument: a user can
+preflight a source, inspect a current structural proxy, trace it to contracts
+and assumptions, compare credible position models on identical inputs, save the
+receipt, and replay the later outcome.
 
-| Order | Outcome | Gate |
-| --- | --- | --- |
-| Now | Produce one bounded credentialed ES Databento report | Explicit credential/data-owner authority and the versioned ES policy |
-| Next | Establish recurrence evidence and evaluate NQ separately | Predeclared observation windows, retained redacted reports, and per-symbol review |
-| Blocked | Build a governed real-session evaluation corpus | Licensed retention/research authority plus a certified provider path |
-| Later | Stabilize research interfaces and live delivery | Reproducible corpus/model evidence and demonstrated user need |
+The roadmap does not assume that GEX predicts price. It separates seven claims:
 
-Version `0.4.0` shipped the repository-owned pre-live hardening under the closed
-[GEX-LIVE-001 packet](docs/work-packets/GEX-LIVE-001.md). Databento still has
-registry status `live-uncertified`: no credentialed report or recurring service
-evidence is claimed.
+1. the software path behaves as specified;
+2. a provider supplied usable data in a declared window;
+3. that behavior recurs within a defined operating envelope;
+4. a structural proxy is descriptively stable or informative;
+5. an alert has out-of-sample predictive value;
+6. an execution rule survives timing, fills, and costs; and
+7. a commercial product retains customers at viable economics.
 
-## Now: Credentialed Databento Evidence
+Evidence at one level does not promote the next.
 
-The only immediate work is external observation. It requires authority to use a
-credential and the relevant market-data entitlements; retaining a capture also
-requires an approved [capture policy](docs/capture-governance.md) before the
-connection opens.
+## Strategic Choice
 
-1. Run `databento-certify` for ES with the canonical multiplier and the
-   versioned ES policy in a declared read-only observation window.
-2. Retain the redacted report, exact package/tag identity, credential and
-   entitlement scope description, and observation-window metadata. Do not
-   retain raw or normalized market data unless the separate capture policy
-   permits it.
-3. Review transport, chain breadth, freshness, sequence, multiplier, IV,
-   shutdown, reconnect, and OI fields as separate evidence. A returned request
-   ID is not a provider acknowledgement, unavailable OI is not trade volume, and
-   an unobserved reconnect cannot be claimed as tested service behavior.
-4. Classify any failure as authentication, entitlement, coverage, payload,
-   temporal, lifecycle, or policy evidence. Repair code only when the evidence
-   identifies a repository defect; otherwise keep the external limitation
-   explicit.
+The working lead hypothesis is a packaged **bring-your-own-data professional
+desktop** built around model provenance, dissent, replay, and evidence receipts.
+It is not yet a chosen commercial product. The MIT research kernel remains
+useful and open; a paid layer, if customer evidence supports one, sells
+convenience, certified workflows, automation, integrations, governed storage,
+and support.
 
-Exit only when a redacted report clears the declared ES policy for its exact
-dataset, symbol, credential, entitlements, configuration, and window. That is a
-bounded observation, not global readiness, predictive validity, execution
-quality, or profitability.
+The strongest alternative is a **hosted ES/NQ tactical cockpit** with simple
+levels, explanations, push alerts, and chart delivery. It has a clearer retail
+promise but requires substantially stronger data licensing, uptime, support,
+mobile UX, and unit economics. Phase 0 decides whether that alternative earns a
+live comparator pilot. Phase 3 is the single authoritative product-path
+decision.
 
-## Next: Recurrence And Separate NQ Review
+## Priority And Gate Map
 
-Before changing provider readiness, route a new packet that defines the number,
-timing, market conditions, and failure tolerance of recurring observations.
-Repeat the same immutable report contract across those windows and preserve
-failures as evidence rather than selecting only successful runs.
+Planning ranges describe likely sequence, not delivery commitments. A phase
+advances on its exit evidence, not because a date elapsed.
 
-Evaluate NQ independently with its own canonical multiplier and policy. ES
-evidence cannot certify NQ. A readiness decision must name the exact supported
-scope and unresolved limitations, including OI availability and any reconnect
-behavior that was not actually observed.
+| Phase | Outcome | Can proceed without live data? | Primary gate |
+| --- | --- | ---: | --- |
+| 0 — Now | Prove the customer wedge and qualify or retire the hosted alternative | Yes | Repeated user job, design partners, data-rights path, and paid-pilot intent |
+| 1 — Next | Make the offline research kernel installable and usable as one product | Yes | Clean-machine activation, stable contracts, safe diagnostics, and reproducible evidence pack |
+| 2 — Parallel external gate | Certify one narrow recurring ES/Databento operating envelope | No | Credential, entitlement, capture authority, exact-run evidence, and predeclared recurrence |
+| 3 | Run a design-partner live beta | Partly | Weekly use, reliable activation, workflow replacement, and no severe trust defects |
+| 4 | Build the governed evidence moat | No for real-session evidence | Licensed corpus, preregistered evaluation, reproducibility, and appropriately narrow claims |
+| 5 | Establish a paid commercial beta | Partly | Distribution/legal readiness, retention, support load, and positive unit economics |
+| 6 | Expand from proven demand | Depends | Independent symbol/provider evidence and demonstrated user demand |
 
-## Blocked Future Outcomes
+The recommended counts and thresholds below are hypotheses to predeclare in a
+work packet. They are not existing measurements and can be changed before data
+collection with a recorded reason.
 
-After the live and recurrence gates have explicit authority and evidence:
+## Phase 0 — Prove The Wedge
 
-- Capture licensed, point-in-time sessions with source, rights, retention,
-  redaction, research-use, cost, symbol, expiry, and as-of metadata.
-- Register immutable train, calibration, and untouched test splits before
+**Purpose:** determine whether a recurring job is valuable enough to build
+around and whether the hosted alternative deserves a later live pilot. The
+local research instrument remains the low-regret lead through Phase 1; this
+phase does not make the final product-path decision.
+
+### Questions to answer
+
+- Does the strongest user want to interrogate and reproduce a structural model,
+  or mainly want trusted ES/NQ levels delivered with minimal effort?
+- Will that user connect an existing provider account, or do they require data
+  bundled into the product?
+- Which existing manual step or paid tool would the product replace?
+- How much setup, model control, and uncertainty will the user tolerate?
+- Is the buying unit an individual trader, a quantitative researcher, a small
+  desk, or a developer team?
+- Do provider terms permit the proposed display, retention, derived output,
+  support, and commercial use?
+
+### Work
+
+1. Recruit 12–15 interview candidates split between quantitative/developer
+   users and advanced ES/NQ traders. Treat existing personas as hypotheses.
+2. Run at least six observed task sessions using current demo and replay data.
+   Ask users to reach a trusted view, explain one level, compare models, save a
+   receipt, and replay the session without developer help.
+3. Prototype both product stories at comparable fidelity:
+   - professional local instrument: Today, Explain, Compare, Replay, Review;
+   - hosted tactical cockpit: current levels, simple explanation, alert, and
+     chart delivery.
+4. Record task completion, time to insight, trust questions, install tolerance,
+   existing data accounts, workflow replacement, and price reaction.
+5. Produce a provider/data-rights matrix covering personal and professional
+   use, non-display calculation, local retention, derived display, external
+   distribution, support access, and termination obligations.
+6. Model the first-year economics for bring-your-own data, bundled data, and a
+   developer/support product. Keep exchange fees and support time explicit.
+
+### Exit gate
+
+- Five users commit to a design-partner beta with a named recurring job.
+- At least three will connect a legitimate existing data account.
+- At least two accept a defined paid-pilot offer at a tested price, subject to
+  the product and commercial terms becoming available.
+- The common recurring job and initial buying-unit hypothesis are explicit;
+  feature enthusiasm alone is insufficient.
+- The bring-your-own-data lead has a written rights path and plausible unit
+  economics.
+- The hosted alternative is either retired or qualifies for the Phase 3
+  comparator with named users, a rights-feasible delivery method, and explicit
+  reasons it could outperform the lead.
+
+### Redirect rules
+
+- If traders want delivery but will not bring data, do not build the hosted
+  comparator until commercial data rights and margin are known.
+- If researchers value the engine but not a desktop workflow, redirect toward
+  a stable SDK plus paid integration/certification support.
+- If neither group identifies a recurring job or replacement, stop product
+  expansion and keep the project an open research workbench.
+
+## Phase 1 — Distributable Research Foundation
+
+**Purpose:** make the existing offline capability installable, coherent, and
+supportable before live beta risk is added. This foundation remains useful as
+the user-facing local product or as the inspectable operator/research layer
+behind a later hosted product.
+
+This phase is repository-owned and can proceed using synthetic, sanitized, and
+rights-cleared inputs.
+
+### Slice 1A — Stable contract and evidence pack
+
+- Define supported read-only Python objects for normalized events, provider and
+  quality state, model profiles, snapshots, comparisons, and experiment
+  artifacts.
+- Publish compatibility, schema-version, deprecation, and migration policies.
+- Add golden contract tests that load artifacts across the declared supported
+  version boundary.
+- Keep mutable state ownership inside the existing consumer; public interfaces
+  must not bypass validation or introduce alternate semantics.
+- Generate one complete shareable evidence pack from a session without asking
+  the user to assemble multiple command outputs.
+
+Exit this slice when the public contract and artifact compatibility tests pass
+across the declared version boundary and a second clean environment can verify
+the one-action evidence pack.
+
+### Slice 1B — Guided offline journey
+
+- Reorganize the visible product around Today, Explain, Compare, Replay, and
+  Review while preserving backward-compatible CLI entry points.
+- Make model disagreement, input quality, and provenance primary surfaces.
+- Let a user drill from a wall, flip, or profile change to the contributing
+  contracts and assumptions.
+- Add a guided first run and an offline `doctor` workflow for version, optional
+  dependencies, configuration, storage, and local resource readiness.
+
+Exit this slice when a clean user reaches the first replay insight in under ten
+minutes and completes Today/Explain/Compare/Replay/Review in under fifteen
+minutes without repository checkout or developer help.
+
+### Slice 1C — Local lifecycle and supportability
+
+- Extend `doctor` to cover credential-store availability, provider selection,
+  and entitlement-readiness checks without opening an unauthorized connection.
+- Use a platform credential-store abstraction where supported; never move
+  secrets into an artifact or support bundle.
+- Add a redacted support bundle with application version, configuration shape,
+  readiness state, recent bounded diagnostics, and artifact identities.
+- Define clean uninstall and local-data deletion behavior.
+
+#### Indexed local data
+
+- Add an indexed local catalog for derived sessions, experiment metadata,
+  model versions, tags, and quality states; raw licensed data remains governed
+  separately.
+- Add explicit migrations, backup/restore, retention enforcement, and deletion
+  tests.
+- Preserve append-only experiment and corpus identity while allowing indexes
+  and disposable derived views to be rebuilt.
+
+Exit this slice when migrations, backup/restore, retention, and deletion pass
+from supported prior states and a generated support bundle contains no
+credential, account identifier, raw licensed payload, or configured sensitive
+value.
+
+### Slice 1D — Supported distribution
+
+- Choose the smallest supported release path based on Phase 0 users: PyPI,
+  Homebrew, a signed standalone application, or a limited combination.
+- Produce checksummed/signed artifacts, a release channel, upgrade and rollback
+  behavior, and clean-machine smoke tests.
+- Test first install, upgrade with existing sessions, failed upgrade, rollback,
+  and uninstall on every supported platform.
+
+Exit this slice when a non-developer installs without repository checkout,
+upgrade and rollback preserve compatible settings and research identities, and
+the full clean-install matrix passes on every supported platform.
+
+### Phase exit
+
+Phase 1 completes only after slices 1A through 1D pass in order. Each slice is
+independently reviewable and releasable; failure in a later slice does not erase
+the evidence from an accepted earlier slice.
+
+## Phase 2 — Narrow Live ES Certification
+
+**Purpose:** establish a bounded, recurring live operating envelope before
+asking design partners to depend on the product.
+
+This phase requires explicit credential, entitlement, data-owner, retention,
+and research authority. It can run in parallel with Phase 1 but cannot be
+declared complete from offline evidence.
+
+### Work
+
+1. Route the exact-run authority and select the canonical ES multiplier,
+   versioned policy, credential/entitlement scope, and declared read-only
+   observation window.
+2. Before running or reviewing the first observation, route a recurrence packet
+   defining observation count, open/midday/close or Globex coverage, market
+   conditions, failure tolerance, retention, and promotion logic.
+3. Run the existing `databento-certify` path and retain redacted successes and
+   failures. Classify authentication, entitlement, coverage, payload, temporal,
+   lifecycle, and policy failures separately.
+4. Measure actual chain breadth, freshness, event ordering, IV path, OI state,
+   restart behavior, shutdown, and any observed disconnect/recovery behavior.
+5. Add watchdog, restart recovery, state resynchronization, and visible degraded
+   modes only where observed evidence identifies the need.
+6. Define the exact supported symbol, session, provider version, configuration,
+   entitlement scope, fallback policy, and operator response for the first beta.
+7. Decide separately whether any live capture may be retained for research. A
+   provider connection does not grant capture or redistribution rights.
+8. After the recurrence gate passes, route a versioned readiness-promotion
+   decision that binds the accepted observation population, policy identity,
+   provider and SDK versions, environment, supported scope, and unresolved
+   limitations. Update the provider registry, documentation, and regression
+   tests together; a passing certification report cannot promote readiness by
+   itself.
+
+### Exit gate
+
+- A redacted exact-run report passes the versioned ES policy for its declared
+  environment and window.
+- Recurring observations satisfy the predeclared promotion rule; failures are
+  retained and explained rather than removed from the population.
+- No silent fallback, stale state, wrong multiplier, cross-contract
+  contamination, or unexplained loss is observed in the accepted envelope.
+- Failure and restart behavior have bounded evidence. An unobserved reconnect
+  remains unclaimed.
+- A reviewed promotion record links the accepted recurrence evidence to the
+  exact registry, documentation, and test changes that establish the new
+  readiness state.
+- `live-certified` names the exact scope and unresolved limitations. It does
+  not imply provider-wide reliability, predictive value, execution quality, or
+  profitability.
+
+### Stop conditions
+
+- If required OI, IV, or chain coverage cannot support the selected job, narrow
+  the job or change the source; do not weaken the evidence label.
+- If licensing prohibits the needed use, retain offline certification and stop
+  the commercial path until a lawful alternative exists.
+- If recurring reliability cannot be demonstrated, do not expose the path as a
+  supported live beta.
+
+## Phase 3 — Design-Partner Live Beta
+
+**Purpose:** determine whether a certified input becomes a repeated user
+workflow rather than merely a technically successful connection.
+
+### Work
+
+- Before onboarding a design partner, establish a signed beta agreement,
+  privacy and telemetry notice with explicit consent, data-handling promises,
+  risk disclaimer, security/vulnerability path, support limits, and incident
+  contact. Phase 5 can harden these for paid scale; it cannot introduce them
+  after live use begins.
+- Deliver four primary live workflows: Today, Explain, Compare, and Replay;
+  Review can begin with daily evidence packs.
+- Show OI, raw-volume, and directionalized-volume agreement or dissent without
+  blending their quantities.
+- Add local rule-based alerts that carry provider, model, as-of, quality, and
+  readiness provenance. A degraded feed suppresses or clearly downgrades an
+  alert according to a predeclared rule.
+- Build one integration selected by Phase 0 evidence. Prefer a local file or
+  webhook/chart bridge before building another full charting surface.
+- Add background operation, bounded recovery, user-visible incident state,
+  and redacted diagnostics.
+- Add opt-in, privacy-safe product analytics for activation and workflow use;
+  never collect raw market data, credentials, private research, or trade/account
+  activity by default.
+- If Phase 0 keeps the hosted alternative viable and written data rights permit
+  it, run a parallel four-week concierge or simulated-delivery cockpit pilot
+  with a comparable cohort and the same activation, repeated-use, replacement,
+  and willingness-to-pay measures. Do not centralize raw licensed data merely
+  to run the comparison.
+- Run structured weekly reviews with design partners and preserve requested
+  features separately from observed workflow failures.
+
+### Exit gate
+
+- Every participant has the applicable beta agreement and telemetry consent;
+  support, incident, security, risk, and data-handling commitments were usable
+  throughout the pilot.
+- At least five design partners use the product weekly for four consecutive
+  weeks.
+- At least 80% install and connect without developer intervention.
+- Median launch-to-trusted-live-view is under five minutes after setup.
+- At least three users say it replaced a named manual step or paid-tool
+  workflow and demonstrate that replacement during observation.
+- At least two users agree to a paid beta for the same defined product.
+- No unresolved high-severity defect can misstate source, freshness, contract,
+  model, or recovery state.
+
+### Product decision
+
+Compare these results with the time-boxed hosted-cockpit pilot. Choose the hosted
+path only if its activation, four-week retention, and willingness to pay are
+materially stronger and the data-rights economics remain viable. Otherwise
+continue with the local professional product.
+
+- **Local wins:** retain the current product vision and use the local-path
+  commercial offer in Phase 5.
+- **Hosted wins:** stop before commercial build-out, update the product vision
+  and this roadmap, and route a hosted architecture/data-rights/privacy/support
+  packet. The Phase 5 local offer does not apply until it is replaced by an
+  accepted hosted plan.
+- **Inconclusive:** extend or narrow the beta; do not start commercial scale
+  work merely to force a decision.
+
+## Phase 4 — Governed Evidence Moat
+
+**Purpose:** learn what the models describe and whether any narrow outcome claim
+survives point-in-time evaluation.
+
+### Work
+
+- Build a licensed corpus spanning volatility, expiry, event, overnight, trend,
+  range, and data-quality regimes.
+- Register immutable train, calibration, and untouched test identities before
   evaluating outcomes.
-- Replay identical sessions through OI, raw-volume, and
-  directionalized-volume models without summing or relabeling their quantities.
-- Publish descriptive disagreement and stability evidence first. Keep
-  `predictive_validity=unmeasured` until governed out-of-sample evidence
-  supports a narrower claim.
-- Define a supported read-only Python research interface before considering
-  REST or MCP contracts.
-- Build multi-symbol scans, alerts, integrations, or hosted views only on
-  provider paths with comparable certified coverage and retained provenance.
+- Externally sign or anchor corpus and manifest identities. Existing unkeyed
+  hashes establish internal consistency, not source authenticity or historical
+  immutability.
+- Compare OI, raw-volume, and directionalized-volume models on identical
+  sessions. Add a licensed participant-attribution model only if its fields and
+  rights establish the claimed semantics.
+- Predeclare horizons, coverage floors, costs, missing-data treatment,
+  multiplicity controls, and promotion criteria.
+- Publish descriptive stability and disagreement first. Preserve null,
+  negative, unresolved, and failed-data results.
+- Distinguish best favorable excursion, adverse excursion, fixed-horizon move,
+  rule-based execution, and account return.
 
-## Deferred
+### Exit gate
 
-Higher Greeks, scenario P/L, broad retail options flow, dark pools, mobile or
-social features, trade execution, and proprietary commentary are not current
-priorities. PyPI publication and a hosted GitHub Release remain separately
-authorized distribution decisions.
+- A clean machine reproduces every published artifact from authorized inputs
+  and registered profiles.
+- The untouched test period remains untouched until the declared decision
+  point; all model changes after inspection receive a new evaluation identity.
+- Coverage and statistical adequacy are reported before interpretation.
+- Claims are promoted only to the narrow level supported by the evidence.
+- If no predictive edge survives, the product remains an explainable
+  market-structure instrument and does not become a signal service.
 
-Contributor-sized offline tasks live in
-[docs/good-first-issues.md](docs/good-first-issues.md), not in this roadmap.
+## Phase 5 — Paid Commercial Beta
+
+**Purpose:** test whether product value exceeds distribution, data, and support
+costs without weakening the evidence contract.
+
+### Local-path offer hypothesis
+
+This offer applies only if the Phase 3 decision selects the local professional
+product. A hosted decision requires a replacement commercial plan before this
+phase begins.
+
+- Keep the MIT offline research kernel available.
+- Sell signed distribution, guided setup, supported live-provider operation,
+  alerts and integrations, governed local evidence storage, updates, and
+  support.
+- Use bring-your-own credentials first. Treat bundled or hosted data as a
+  separate business decision requiring written provider and exchange authority.
+- Do not make previously MIT-licensed code scarce retroactively; any future
+  proprietary module needs a deliberate boundary and user-visible value.
+
+### Work
+
+- Convert the beta agreement, privacy/telemetry notice, data-handling promises,
+  support limits, incident process, and risk disclaimer into production-facing
+  commercial terms; add refunds and vendor obligations and obtain the
+  appropriate professional review.
+- Add payment and entitlement only after Phase 0 and Phase 3 price evidence.
+- Operate signed release channels, auto-update or guided update, migrations,
+  rollback, support bundles, and a vulnerability/incident process.
+- Measure activation, active use, retention, cancellation reason, support time,
+  infrastructure, vendor fees, payment costs, and refunds.
+- Keep marketing claims linked to the live, empirical, and commercial evidence
+  that actually supports them.
+
+### Exit gate
+
+- Ten paying pilots use the same supported offer.
+- At least 60% remain active through eight weeks.
+- Supported-provider activation is under fifteen minutes for the median new
+  customer.
+- Support burden remains below thirty minutes per customer per week after the
+  first two weeks.
+- Gross contribution is positive after provider, distribution, payment,
+  infrastructure, refund, and support costs.
+- No commercial claim exceeds the declared provider, model, or outcome evidence.
+
+These are pilot thresholds, not a forecast of market size or revenue.
+
+## Phase 6 — Expand From Proven Demand
+
+Expansion is a sequence of separate gates, not a bundle:
+
+1. **NQ:** certify independently with its multiplier, contract family, chain
+   coverage, sessions, and policy. ES evidence cannot certify NQ.
+2. **Headless local service:** expose the stable domain contract through a
+   bounded local process and WebSocket only after the Python contract is stable.
+3. **REST or MCP:** add the interface users actually request while preserving
+   the same provenance and rights controls. Do not expose raw licensed data by
+   accident.
+4. **Second integration:** choose from demonstrated user workflow, not vendor
+   logo count.
+5. **Multi-symbol scan:** rank structural change only across provider paths
+   with comparable certified coverage and quality.
+6. **Research teams:** share rights-cleared derived artifacts, manifests, and
+   evaluation results; keep credentials and raw licensed inputs local unless a
+   separate agreement permits central handling.
+7. **Higher Greeks:** add vanna, charm, delta exposure, or scenario P/L only
+   when the chosen user job requires them and independent numerical/evidence
+   gates exist.
+8. **Additional futures complexes:** evaluate rates, metals, or energy one
+   contract family at a time. Liquidity, expiry, multiplier, exercise, and data
+   semantics require their own policies.
+9. **Evidence-aware assistance:** allow natural-language explanation over
+   authorized local artifacts only after citations, abstention, and proof-ceiling
+   enforcement are testable. Do not create automated trade calls.
+10. **Hosted delivery:** centralize derived or raw data only after written
+    rights, privacy, support, reliability, and unit economics justify it.
+
+## Cross-Cutting Product Metrics
+
+| Dimension | Measure | Why it matters |
+| --- | --- | --- |
+| Activation | Time to first replay insight; time to trusted live view | Separates feature completion from user access |
+| Repeated value | Weekly completion of the chosen recurring job | A product needs habit or repeated workflow replacement |
+| Trust | Provenance/staleness defects, suppressed alerts, unresolved data incidents | One silent wrong state can destroy the core promise |
+| Research integrity | Reproducibility rate, corpus coverage, split violations, null-result retention | Measures whether the evidence moat is real |
+| Reliability | Accepted-window success, freshness, recovery, and clean-stop evidence within exact scope | Prevents “connected once” from becoming a service claim |
+| Commercial fit | Paid conversion, eight-week retention, replacement evidence, and cancellations | Tests actual value rather than compliments |
+| Economics | Contribution after data, support, distribution, payment, and infrastructure costs | Prevents a popular workflow from becoming an unviable product |
+
+Metric definitions, populations, and observation windows must be fixed before a
+phase uses them as a gate.
+
+## Principal Risks And Responses
+
+| Risk | Early signal | Response |
+| --- | --- | --- |
+| Commodity feature trap | Users compare only walls and price | Lead with dissent, provenance, replay, and receipts; stop chasing panel parity |
+| No recurring user job | Interviews produce feature lists but no repeated replacement | Remain a research project or narrow to the SDK/support path |
+| Data-rights mismatch | Desired hosted/display use is not authorized or destroys margin | Keep bring-your-own credentials and local processing; narrow the offer |
+| Live path instability | Recurrence failures or silent degradation | Do not promote readiness; repair from evidence or change provider |
+| False causal certainty | Users interpret GEX as observed dealer inventory or guaranteed support | Make proxy, quality, alternative models, and disconfirmation visible |
+| Research overfitting | Results change after test inspection or only wins are retained | Enforce registered splits, new identities, full populations, and null results |
+| Support-heavy distribution | Setup and data issues consume the margin | Improve doctor/setup, narrow the supported envelope, or sell higher-touch B2B support |
+| Open-core confusion | Paid value appears to hide previously open calculation | Keep the kernel useful and charge for operational layers with explicit boundaries |
+| Premature breadth | Higher Greeks, flow, news, mobile, and AI delay the core loop | Require repeated user evidence and a phase gate for every expansion |
+
+## Explicitly Not Now
+
+- Broad equity-options flow or dark-pool aggregation
+- Political, news, social, or community feeds
+- Automated trade recommendations or brokerage execution
+- A mobile-first application
+- A centrally hosted raw market-data lake
+- A proprietary composite score that hides model disagreement
+- Multi-provider or multi-asset breadth before one ES path is supported
+- Higher Greeks added solely for competitive checklist parity
+- REST, MCP, or numerous chart integrations before the domain contract is stable
+- Predictive, execution, or profitability marketing before corresponding evidence
+
+## Immediate Continuation Point
+
+The next governed product packet should own Phase 0 only: interview protocol,
+two comparable prototypes, acceptance tasks, data-rights matrix, commercial
+hypotheses, metric definitions, and the product-path decision. Phase 1 can begin
+with reversible contract and clean-install work, but should not choose a broad
+distribution surface before Phase 0 identifies the first user and buying model.
+
+The existing credentialed ES observation remains a separate external evidence
+gate under Phase 2. Do not hold customer discovery or offline product design
+hostage to live data, and do not let offline product progress imply live
+readiness.
+
+Contributor-sized offline tasks remain in
+[Good First Issues](docs/good-first-issues.md), not in this strategic roadmap.

--- a/docs/market-analysis.md
+++ b/docs/market-analysis.md
@@ -1,266 +1,287 @@
-# Competitive Landscape and Product Positioning
+# Competitive Landscape and Product Strategy
 
-External market sources were reviewed August 14, 2026; repository capability
-claims were reconciled to the `0.3.0` tree on August 31, 2026. This replaces the
-June 12 market snapshot. Pricing, coverage, entitlements, and vendor features
-change frequently; recheck the linked first-party sources before reusing price
-or package claims.
+External market sources and public product materials were reviewed on
+September 3, 2026. Repository capability claims were reconciled to the `0.4.0`
+tree. Pricing, coverage, data rights, entitlements, and vendor features change
+frequently; recheck the linked first-party sources before reusing a specific
+claim.
 
 ## Executive Answer
 
 | Question | Answer |
 | --- | --- |
-| Where does `gex-terminal` fit? | An open, local-first GEX model laboratory and market-structure research workbench for quants, developers, data engineers, and evidence-sensitive futures-options traders who want to own and interrogate the calculation. |
-| Is the product unique? | Not because it calculates GEX, shows walls or a flip, runs locally, or is free. Each of those exists elsewhere. The differentiated claim is the combination of provider-normalized inputs, futures-aware Black-76 calculations, explicit provenance, side-by-side position-model comparison, deterministic replay, and fail-closed evidence boundaries. That combination is distinctive in this public scan, but it is not proof that no public or private product has an equivalent. |
-| Is price the differentiation? | No. The MIT software price is an adoption wedge, but Barchart offers meaningful delayed GEX from $0 to $29.95/month and open-source alternatives are free. A useful live futures feed can also cost more than a retail app. Total cost includes data, setup, maintenance, and user time. |
-| Is tunability the differentiation? | Partly. Inspectable and replaceable assumptions are valuable, but Barchart and open-source projects already expose many controls. Tunability becomes defensible when it is joined to identical-session replay, data lineage, model diffs, and saved experiment manifests. |
-| What does building this provide? | Control of the calculation and data path; reproducible research; the ability to compare OI, raw-volume, and directionalized-volume proxies on the same capture; provider independence; a contributor workbench; and an honest boundary between numerical correctness and measured trading value. |
-| What does it not yet provide? | A production-certified live ES/NQ workflow, observed dealer inventory, independently validated predictive edge, broad flow/dark-pool coverage, a polished hosted/mobile experience, or necessarily the lowest total cost. |
+| What does the current market signal? | The reviewed public offers make baseline GEX charts easy to obtain and increasingly package interpretation, intraday position estimates, replay, public outcome records, chart integrations, APIs, MCP surfaces, and AI-assisted synthesis around them. This is a current-snapshot inference, not a longitudinal adoption study. |
+| What are the closest new threats by overlap? | [GammaTape](https://gammatape.com/) overlaps most with the focused ES/NQ trader workflow through SPX/NDX 0DTE levels, replay, and chart delivery. [FlashAlpha](https://flashalpha.com/pricing) overlaps most with the native-futures developer workflow. Both make “GEX for futures traders” insufficient positioning. |
+| Why is Nightglass important? | [Nightglass](https://nightglass.trade/) publicly positions itself as options-flow research; the reviewed materials did not establish native futures-options coverage. Its importance is product design: it narrows raw data, explains why an item survived, joins it to a decision workflow, and keeps a public outcome record. |
+| Where can `gex-terminal` win? | As the auditable, futures-native market-structure workbench for ES/NQ: every level traces to a source, contract, timestamp, model, quality state, and evidence ceiling; competing position models can be replayed on identical inputs. |
+| What is not a moat? | Basic GEX math, call-positive/put-negative signs, walls, flips, a local dashboard, free software, or Black-76 by itself. Each is already available elsewhere. |
+| What could become a moat? | A governed corpus of point-in-time futures-options sessions plus reproducible provider/model comparisons, visible disagreement, and an honest record of descriptive and outcome evidence. That moat does not exist yet. |
+| What should the first commercial shape be? | Test a packaged bring-your-own-data desktop product first. Keep the MIT research kernel open; charge, if users validate the model, for distribution, certified live workflows, automation, integrations, governed storage, and support. |
 
 The recommended position is:
 
-> **Own and interrogate the model.** `gex-terminal` is a local-first,
-> provider-normalized research laboratory for equity, index, and native futures
-> options. Every output carries its assumptions, provenance, quality state, and
-> evidence ceiling, and the same captured session can be replayed across
-> competing methodologies.
+> **Know what produced the level.** `gex-terminal` is a local-first ES/NQ
+> market-structure instrument for researchers and advanced traders who want to
+> inspect the data, assumptions, model disagreement, quality state, and later
+> outcome behind every GEX proxy.
 
-This is intentionally narrower than “a cheaper SpotGamma” or “another options
-flow dashboard.”
+This is narrower than a broad options-flow terminal and more defensible than
+“another gamma dashboard.”
 
 ## Method and Evidence Boundary
 
-This review used:
+This review used first-party vendor product, pricing, methodology, integration,
+and documentation pages; exchange and clearing-volume publications; public
+source repositories; and the current application, tests, and documentation.
 
-- first-party pricing, product, documentation, and methodology pages;
-- public repository documentation for open-source alternatives; and
-- the current `gex-terminal` code, tests, assumptions, architecture, and
-  [roadmap](../ROADMAP.md).
+The review did not include paid trials, customer interviews, independent
+latency or uptime measurement, contract or regulatory advice, subscriber
+counts, retention, realized performance, or private enterprise features.
+Vendor feature, accuracy, asset-count, “real-time,” and performance statements
+remain vendor claims unless an exchange or clearing source is explicitly named.
+An unavailable public detail is recorded as unknown, not assumed absent.
 
-The scan compares publicly documented capabilities as of August 14, 2026. It
-does not include paid hands-on trials, independent latency measurement, model
-accuracy tests, realized performance, contract review, or private enterprise
-features. Asset counts, “real-time” labels, and historical depth are vendor
-claims unless explicitly stated otherwise. Prices are closest relevant public
-list prices, not equivalent bundles; taxes, professional status, market-data
-fees, and billing cadence may change the comparison.
+Strategic comparisons are qualitative. “Closest” means greatest overlap with
+the intended user and workflow across five lenses: native ES/NQ inputs, model
+inspectability, live/replay parity, evidence record, and delivery/developer
+surface. It does not mean best overall product. Industry-direction statements
+are inferences from the current public offer set plus the cited volume history;
+this review did not measure vendor adoption or feature changes over time.
+
+[Nightglass's public terms](https://nightglass.trade/terms) restrict competitive
+reuse and reverse engineering. This review uses public category facts only. Do
+not copy its interface, content, alert outputs, thresholds, or proprietary
+scoring logic.
+
+## Current Industry Signals
+
+| Observable change | Current evidence | Product consequence |
+| --- | --- | --- |
+| Options participation is still expanding | [OCC's July report](https://www.theocc.com/newsroom/views/2026/08-04-july-2026-monthly-volume-report) shows 2026 year-to-date U.S. options average daily volume of 70.82 million contracts, 23.9% above the comparable 2025 period. | More raw data increases the value of filtering, context, and trustworthy state management. |
+| Same-day options dominate SPX activity | [Cboe reported](https://www.cboe.com/insights/posts/market-metrics-that-matter-derivatives-july-2026-volume-highlights) that 0DTE contracts reached 66.2% of SPX volume in July 2026. | Overnight OI alone is least informative exactly where many intraday products make their strongest claims. Intraday quantity semantics must stay explicit. |
+| Native futures-options activity is material and around the clock | [CME reports](https://www.cmegroup.com/articles/2025/equity-index-options-state-of-play.html) equity-index options-on-futures ADV grew from more than 700,000 in 2020 to 1.4 million in 2025; ES reached 1.3 million and NQ 87,000. | A native ES/NQ path is a real market, not just a translation of SPX/NDX levels. Globex sessions also make an RTH-only product incomplete for some users. |
+| The popular causal story is contested | A [Cboe study](https://www.cboe.com/insights/posts/0-dt-es-decoded-positioning-trends-and-market-impact) estimated balanced customer activity left net SPX 0DTE market-maker gamma hedging at no more than about 0.2% of daily SPX liquidity in its study. | GEX should be presented as a model-dependent structural proxy and competing hypothesis, not an observed cause of every move. |
+| Public products package data into decisions | Nightglass, SpotGamma, MenthorQ, and TradingFlow organize data around preparation, filtering, interpretation, delivery, and review. | A product needs a coherent daily job, not a collection of metrics and commands. |
+| Trust is a visible product surface | Nightglass exposes a public alert record; replay and historical views are common; several vendors publish formulas or methodology pages. | Reproducibility, complete populations, preregistered definitions, and null results can differentiate more than marketing screenshots. |
+| Delivery reaches the user's existing workflow | MenthorQ and GEXBot advertise multiple chart integrations; Quant Data, Unusual Whales, FlashAlpha, and Optionomics advertise API or MCP access. | A terminal-only surface is insufficient long term. Stable local interfaces should precede integrations. |
+| Offers span wide price and service bands | Free/open and $39–$75 products coexist with roughly $99–$349 trader offers and substantially more expensive API, history, or enterprise access. | Price alone is weak positioning. Data rights, time saved, support, and evidence quality determine total value. |
 
 ## Current Product Truth
 
-### Shipped strengths
+### Assets already in the repository
 
 - Contract-aware Black-76 for futures options and Black-Scholes for
-  equity/index options, with explicit expiry, multiplier, IV, position-source,
+  equity/index options, with expiry, multiplier, IV, position-source,
   event-time, and pricing-model provenance.
-- OI, raw-volume, and aggressor-directionalized volume models kept separate,
-  with coverage and disagreement reporting rather than silently blended.
-- Local replay browser, captured-session store, historical journal, Replay Lab,
-  Demo Lab, provider-fixture workbench, sensitivity reports, and exportable
-  snapshots.
-- Normalized adapter boundary spanning replay, yfinance, provider-shaped
-  fixtures, and implemented or scaffolded Tradovate, Databento, and IBKR paths.
-- A numerical evidence gate and explicit
-  `predictive_validity=unmeasured` ceiling.
-- Versioned model profiles, reproducible experiment manifests, append-only
-  corpus registration, and batch day/expiry/DTE-layer model comparisons.
-- MIT source, deterministic fixtures, contributor tests, and local credential
-  handling.
+- Open-interest, raw-volume, and aggressor-directionalized volume models kept
+  separate, with coverage and disagreement reporting.
+- Deterministic replay, captured sessions, journals, experiment manifests,
+  model profiles, append-only corpus registration, and batch comparison.
+- A normalized provider boundary spanning replay, delayed data,
+  provider-shaped fixtures, and implemented or scaffolded live paths.
+- Versioned certification policies, lifecycle and fault tests, redaction, safe
+  capture policy, and explicit readiness/evidence vocabularies.
+- Local exports, TradingView level files, a Textual interface, and an MIT
+  contributor surface.
 
-### Material constraints
+### Commercial gaps
 
-- Replay and fixture paths are software-certified; no provider is yet
-  production-certified end to end for credentialed, entitlement-backed live
-  ES/NQ chain discovery.
-- Open interest and trade volume remain positioning proxies. Aggressor side
-  does not establish dealer/customer identity or opening/closing state.
-- Synthetic fixtures and integrity-checked captures do not establish market
-  edge, forecast validity, fill quality, or P&L.
-- Alerts and TradingView outputs are local files, not hosted push, webhook, or
-  native chart integrations.
-- There is no stable public Python/REST/MCP contract, multi-symbol live scanner,
-  DEX/vanna/charm production surface, or options-flow tape.
-- The terminal is a poor fit for new, mobile-first, or commentary-seeking
-  traders.
+- Databento remains `live-uncertified`; no provider has a supported recurring
+  production envelope for credentialed ES/NQ.
+- `predictive_validity=unmeasured`; there is no governed real-session corpus or
+  out-of-sample evidence of trading value.
+- The personas are hypotheses derived from product reasoning, not validated
+  customer segments with observed activation, retention, or willingness to pay.
+- Installation still assumes a Python environment. There is no signed desktop
+  build, updater, migration/rollback contract, or guided provider setup.
+- The CLI is broad and flat. There is no supported read-only Python API, local
+  service, WebSocket, REST, or MCP contract.
+- Alerts and overlays are local artifacts, not a reliable background delivery
+  loop or chart bridge.
+- There is no commercial data agreement, billing, support policy, incident
+  process, privacy posture, or measured unit economics.
+
+The code is a credible research kernel. The missing work is product validation,
+live operational proof, packaging, daily workflow, and commercial authority—not
+another formula.
 
 ## Market Map
 
-The category now has five overlapping product types:
+The public market now clusters into six overlapping product types:
 
-1. **Premium trader terminals:** SpotGamma, MenthorQ, GammaEdge, Volland, and
-   TradingFlow package levels, visual workflows, education, integrations, and
-   commentary.
-2. **Broad retail options platforms:** Unusual Whales, Quant Data, Tradytics,
-   and similar products combine flow, dark pools, scanners, alerts, and Greek
-   exposure.
-3. **Developer data/API products:** Quant Data API, Unusual Whales API,
-   FlashAlpha, SqueezeMetrics research data, and raw providers such as
-   Databento reduce the need to build ingestion or calculations from scratch.
-4. **Budget and generalist tools:** Barchart, OptionCharts, TradingView, and
-   thinkorswim cover much of the visible workflow at low or bundled prices.
-5. **Open and self-hosted projects:** GammaGrid, gex-dashboard, Futures Options
-   S/D Dashboard, 0DTE Dealer Gamma, and simpler GEX scripts commoditize the
-   basic calculation and increasingly cover local history, replay, APIs, and
-   futures options.
+1. **Interpretation and research desks:** Nightglass, SpotGamma, and
+   TradingFlow reduce a large tape or model surface to a daily research path.
+2. **Futures-facing GEX products:** GammaTape and MenthorQ deliver index or
+   futures gamma context into ES/NQ trader workflows.
+3. **Model-rich exposure terminals:** GEXBot, OptionsDepth, Volland, GammaEdge,
+   and SqueezeMetrics compete on position inference, Greeks, history, or
+   specialized displays.
+4. **Broad retail intelligence platforms:** Unusual Whales, Quant Data,
+   Tradytics, and Optionomics bundle flow, dark pools, alerts, AI, mobile, and
+   exposure analytics.
+5. **Developer data and analytics:** FlashAlpha, Quant Data API, Unusual Whales
+   API, and raw providers such as Databento make buying an interface easier
+   than building one for many users.
+6. **Open and budget tools:** GammaGrid, gex-dashboard, futures-options
+   dashboards, Barchart, and small scripts commoditize the baseline calculation
+   and increasingly offer history or replay.
 
-### Direct and high-pressure competitors
+## Nightglass Deep Dive
 
-| Product | Closest relevant public price | Strongest overlap | Where it is ahead | Where `gex-terminal` can differ |
-| --- | ---: | --- | --- | --- |
-| [SpotGamma](https://spotgamma.com/subscribe-to-spotgamma/) | Essential $99/mo; Alpha $299/mo; annual discounts | GEX levels, walls, gamma/volatility regimes, 0DTE tools | Category authority, polished SPX workflow, proprietary participant lenses, education, commentary, TRACE/HIRO history | Open calculations, interchangeable inputs, local ownership, model-level controls, provider provenance, reproducible same-session comparisons |
-| [MenthorQ](https://menthorq.com/pricing/) | Premium $129/mo after promotion; Pro $349/mo after promotion | ES/NQ gamma levels and futures workflow | 1,400+ claimed assets, five-minute gamma updates, TradingView/NinjaTrader/Sierra/Bookmap and other integrations | Local engine, inspectable assumptions, normalized provider path, replay/evidence artifacts, user-replaceable models |
-| [Barchart GEX](https://www.barchart.com/stocks/quotes/AAPL/gamma-exposure) | Free; Premier $29.95/mo or $239.95/yr | GEX/DEX, flip, walls, expiry and OI/volume controls | Best budget direct substitute; consolidated OPRA input, chart UI, expected move, intraday/EOD modes, published formulas, Premier CSV | Native futures-option path, local calculation, provider normalization, full provenance, captured-session replay, method comparison |
-| [Unusual Whales](https://unusualwhales.com/pricing) | Retail $50/$75/$120 per month; API from $150/mo | GEX heatmaps, SPX exposure, flow, dark pools, alerts, API | Broad tape and market coverage, one-minute top-tier SPX exposure, established retail UX, WebSocket/MCP/API surfaces | Local user-owned engine and data, explicit model replacement, deterministic offline replay, stricter evidence ceilings |
-| [Quant Data](https://quantdata.us/api) | Dashboard $74.99/mo; API $149.99/mo | GEX/DEX/vanna/charm, flow, history, REST/MCP | Strong documented developer surface, 6,000+ claimed tickers, intraday maps, history, broad options analytics | Vendor-calculation independence, raw model control, futures-native focus, provider/method comparison, local research ownership |
-| [FlashAlpha](https://flashalpha.com/pricing) | Growth $299/mo for CME futures; Alpha $1,499/mo for deep history | API-first GEX and higher Greeks, ES/NQ, Black-76, history/replay | Closest public API threat to the quant/developer/futures niche; vendor claims CME futures, SDKs/MCP, full-chain levels, flow, and minute history at higher tiers | Open engine, BYO provider, local replay, explicit evidence ceilings, independent comparison instead of consuming one vendor estimate |
-| [TradingFlow](https://tradingflow.com/) | $69/mo or $49/mo annual equivalent | GEX/DEX, flow tape, replay, filters and CSV | Strong value bundle and trader-facing “Time Machine” workflow | Formula-level tunability, futures-native research, local provider path, repeatable experiment artifacts |
-| [GammaEdge](https://www.gammaedge.com/) | $150/mo or $125/mo annual equivalent | GEX/DEX/charm/vanna and market-structure levels | Education, community, Discord delivery, proprietary trend workflow | Open math, provider/data provenance, research replay, developer extensibility |
-| [Volland](https://vol.land/pricing) | From $99/mo; advanced tiers $150-$1,000/mo | Dealer-positioning and multi-Greek analysis | Strong public description of transaction/quote-based dealer-side inference; advanced trader workspaces | Open implementation, lower entry cost, provider independence, deterministic local comparison; licensed participant evidence remains a roadmap gap |
+Nightglass matters less for feature parity than for showing how a market-data
+tool becomes a product.
 
-### Open-source and self-hosted pressure
-
-| Project | Publicly documented capability | Implication |
+| Dimension | Publicly documented fact | Lesson for `gex-terminal` |
 | --- | --- | --- |
-| [GammaGrid](https://github.com/gammagrid/gammagrid) | AGPL self-hosted app with local SQLite, GEX, heatmaps, walls/flip, IV surface, full Greeks, history, and replay using delayed yfinance snapshots | “Open, local, and replayable” is no longer unique. Native futures providers, provider normalization, and evidence discipline are the stronger line. |
-| [Darthreign/gex-dashboard](https://github.com/Darthreign/gex-dashboard) | MIT local package with GEX/DEX, 0DTE, vanna/charm, OI changes, history, Parquet/export, MCP, optional ES/NQ and provider backfill | The closest open-source feature threat found. Its free data-path durability and redistribution rights require separate review; `gex-terminal` still needs a clearer API and better visuals. |
-| [Futures Options S/D Dashboard](https://github.com/Hewkaw02/Futures-Options-SD-Dashboard) | MIT credentialed CME futures dashboard using Black-76, GEX profiles, vanna, walls/flip, time travel, exports, and data-quality scoring | Futures-native Black-76 is not unique. Evidence-bounded model comparison and provider-normalized research must do more work. |
-| [0DTE Dealer Gamma](https://github.com/puneet-chandna/0DTE-dealer-gamma) | Source-available SPX dashboard with FastAPI/Next.js, provider registry, Postgres history, WebSocket updates, and vectorized Black-Scholes | A polished open dashboard is attainable. The project is noncommercially licensed and equity-index focused, but it raises the UX bar. |
-| [gex-tracker](https://github.com/Matteo-Ferrara/gex-tracker) and similar scripts | Basic call-positive/put-negative GEX calculation and charting | Strong evidence that the core math and standard walls/flip outputs are commodity features. |
+| Customer job | It targets active traders who want useful options-flow research without manually interpreting the entire tape. | Sell a reduction in a recurring job, not access to a calculation. |
+| Workflow | [The platform](https://nightglass.trade/product/) connects filtered alerts, ticker analysis, market and catalyst context, and post-close review. | Organize `gex-terminal` around Today, Explain, Compare, Replay, and Review rather than exposing the CLI taxonomy to users. |
+| Interpretation | [Its method](https://nightglass.trade/methodology/) considers relative size, volume versus OI, execution urgency, repetition, related structures, and the event window; it permits an unresolved read. | Make abstention and model disagreement first-class. A data point does not have to become a signal. |
+| GEX role | SPX dealer gamma is supporting context; price structure and invalidation remain central to the trade plan. | Do not present a wall as a guaranteed destination or cause. Show what would disconfirm the structural read. |
+| Proof | Its first public audit covers 443 alerts over 15 sessions and reports favorable excursion statistics. The site separately states that peak moves are not subscriber returns. | A visible record builds trust, but a short vendor-authored best-move study is not execution evidence. Fixed horizons, costs, chronology, full populations, and reproducible artifacts would be stronger. |
+| Pricing | One membership is listed at $149 monthly or $1,500 annually. | Buyers may pay for curation and saved attention, but price does not establish customer count, retention, or fit for this app. |
+| Unknowns | Public pages reviewed did not establish its provider, measured latency, SLA, API, raw export contract, chart bridge, or native futures-options coverage. | `gex-terminal` should make those operational and provenance facts explicit rather than merely asserting quality. |
 
-### Adjacent products to integrate with, not clone
+Nightglass's best lesson is the complete loop: select what matters, explain why,
+connect it to a decision, and preserve the record. Its weakest transferable
+lesson would be copying an interpretation product before `gex-terminal` has
+live inputs and empirical evidence.
 
-- [TradingView](https://www.tradingview.com/pricing/) is the charting and alert
-  layer to feed. Pine cannot reliably replace a licensed live options-chain
-  input, so portable audited levels and automation are the opportunity.
-- [Schwab thinkorswim](https://www.schwab.com/trading/thinkorswim) is a strong
-  broker-connected options, Greeks, scan, simulation, and execution workflow.
-  It does not publicly document a comparable aggregate, replayable GEX model
-  laboratory.
-- [Cboe delayed quotes](https://www.cboe.com/delayed_quotes/spx/quote_table)
-  provide manual reference inputs, Greeks, IV, and OI—not a governed automated
-  GEX research feed. Public-page extraction restrictions make licensed adapter
-  paths important.
-- [OptionStrat](https://optionstrat.com/membership) is a better trade-construction
-  and P/L experience. Its strengths are a reason to defer a generic strategy
-  builder until the core research niche is proven.
+## Competitive Pressure
 
-## Best in the Industry by Job
+Prices are closest relevant public list prices on the review date, not
+equivalent bundles. Promotions, billing cadence, exchange fees, professional
+status, and commercial rights can change total cost.
 
-These are evidence-bounded judgments from public documentation, not hands-on
-rankings of latency, accuracy, support, or realized results.
-
-| Job | Current benchmark | Why it matters to the roadmap |
-| --- | --- | --- |
-| Polished SPX/dealer workflow | SpotGamma | Sets the UX, explanation, 0DTE, and category-trust bar. |
-| Turnkey futures trader workflow | MenthorQ | Sets the cross-platform integration and low-friction ES/NQ bar. |
-| Broad retail options intelligence | Unusual Whales | Shows the value of tape, flow, alerts, breadth, and one product surface. |
-| Developer/API access | Quant Data; FlashAlpha is the closest futures-method threat | Makes a paid API faster than building for users who do not require local ownership or replaceable math. |
-| Public dealer-side inference explanation | Volland and SqueezeMetrics | Demonstrates how far position attribution can move beyond the standard sign convention. |
-| Budget direct GEX | Barchart | Removes low price and basic tunability as defensible claims. |
-| Open/local direct comparator | GammaGrid; gex-dashboard for feature breadth | Removes generic “open and replayable” positioning. |
-| Visualization and alerts | TradingView | The sensible strategy is export/integration, not chart-platform replacement. |
-
-## Differentiation Assessment
-
-| Dimension | Current strength | Competitive conclusion | Product implication |
+| Product | Public offer most relevant here | Where it is ahead | Opening for `gex-terminal` |
 | --- | --- | --- | --- |
-| Sticker price | Medium | Free software helps, but free pages, low-cost Barchart, and open-source peers exist. Live data may erase the savings. | Use price as adoption, education, and contributor access—not the positioning headline. |
-| Model tunability | Medium-high | Valuable, but UI controls and open code exist elsewhere. | Make the shipped model profiles, experiment manifests, and identical-session diffs a visible primary workflow. |
-| Auditability and provenance | High | Many vendors explain concepts; fewer expose a replaceable engine with per-output input and model provenance. | Keep every calculation traceable to provider, timestamp, IV source, multiplier, position source, pricing model, and quality state. |
-| Reproducibility | High offline | Local history/replay exists elsewhere, but the same normalized replay across competing methodologies is less common. | Make model/provider comparison the hero workflow, not a secondary CLI. |
-| Futures-native correctness | Medium-high | MenthorQ, FlashAlpha, and open-source futures dashboards now support this space. | Certify real ES/NQ first, extend to GC only after the contract/data path is stable, and benchmark Black-76 outputs. |
-| Evidence discipline | High | Explicitly separating math, software-path tests, live certification, identity inference, and predictive value remains unusual. | Turn the evidence ledger and governed capture corpus into a visible product surface. |
-| API/developer ergonomics | Low-medium | Quant Data, Unusual Whales, FlashAlpha, and some open-source peers are easier to build against. | Publish a stable read-only Python/library contract, then local REST/MCP if demand is proven. |
-| Live trader experience | Low | Premium vendors win on integrations, automatic updates, alerts, support, and commentary. | Do not claim production substitution until one live path and delivery loop are certified. |
+| [GammaTape](https://gammatape.com/) | Free archive; Pro $99/month; Max $249/month | Focused SPX/NDX-to-ES/NQ workflow, near-real-time levels, 30/90-day replay, and MotiveWave delivery | Native options-on-futures rather than cash-index mapping; provider/model provenance; model-dissent and evidence receipts |
+| [FlashAlpha](https://flashalpha.com/pricing) | Growth $299/month; Alpha $1,499/month | Native CME options-on-futures, Black-76, ES/NQ and wider coverage, SDKs/MCP, history, higher Greeks, and quality monitoring | Open and replaceable engine, bring-your-own provider, local privacy, identical-input comparison, and independently reproducible claims |
+| [GEXBot](https://www.gexbot.com/docs) | Public price was not reliably exposed in this review | Intraday state model, replay, high visual tunability, higher Greeks, alerts, APIs, and many chart integrations | Native futures-options chain, Globex coverage, open method implementation, and explicit evidence ceilings |
+| [SpotGamma](https://spotgamma.com/subscribe-to-spotgamma/) | Essential $99/month; Alpha $299/month | Category trust, research/commentary, polished SPX/0DTE workflow, proprietary flow lenses, education, and community | Local ownership, direct futures contracts, replaceable assumptions, provenance, and reproducible model comparison |
+| [MenthorQ](https://menthorq.com/pricing/) | Premium $129/month; Pro $349/month after introductory offers | Broad coverage, education, AI, and the deepest advertised chart-platform integration set | Inspectable calculations and data lineage; public materials reviewed leave native futures-gamma cadence and real-time recomputation unclear |
+| [OptionsDepth](https://optionsdepth.com/pricing) | Pro $199/month; Pro Max $249/month | Participant-tagged Cboe positioning, intraday SPX/VIX views, higher-Greek maps, and trader workspace | Native CME inputs, open models, local replay, lower dependency on one participant dataset |
+| [Nightglass](https://nightglass.trade/) | $149/month or $1,500/year | Interpretation-first daily workflow, complex-trade reconstruction, education, and public record | Futures-native model laboratory, formula/data provenance, governed replay, and stronger experimental discipline |
+| [Unusual Whales](https://unusualwhales.com/pricing) | Retail $50/$75/$120 monthly; API from $150/month | Breadth, tape, alerts, mobile, community, dark pools, API/MCP, and enterprise data surfaces | Narrower ES/NQ job, local control, replaceable models, and less opaque evidence boundaries |
+| [Quant Data](https://quantdata.us/api) | Dashboard $74.99/month; API $149.99/month | Accessible dashboard/API, broad U.S. options analytics, MCP, history, and published service claims | Native futures-options research, open calculation, provider comparison, and governed experiment artifacts |
+| [Optionomics](https://optionomics.ai/pricing) | $39–$99/month | Low-priced history, flow, AI, public track record, backtesting, REST, MCP, alerts, and mobile distribution | Futures-native depth, local privacy, model provenance, and defensible evidence rather than breadth |
+| [TradingFlow](https://tradingflow.com/pricing/) | $59/month, billed quarterly | Strong filtered-flow workflow, live tape, saved views, exports, and evidence-aware methodology language | Direct CME focus, open engine, same-session model comparison, and research governance |
+| [GammaGrid](https://github.com/gammagrid/gammagrid) and open peers | Free/open source | Self-hosting, transparent code, visual dashboards, stored snapshots, Greeks, and replay | Certified live futures inputs, provider normalization, stronger temporal contracts, and explicit proof ceilings |
 
-The most durable prospective moat is not the TUI, wall calculation, or free
-license. It is a growing corpus of governed point-in-time captures plus a
-trusted history of model/provider comparisons, explicit lineage, and honest
-validation results. That moat has not yet been built.
+### Closest benchmarks by job
 
-## Persona Fit
+| Job | Benchmark | What must be learned rather than copied |
+| --- | --- | --- |
+| Daily interpretation and trust | Nightglass | A coherent decision loop and visible record |
+| Focused ES/NQ trader UX | GammaTape | Put levels where the trader already works; replay is a primary surface |
+| Native futures developer surface | FlashAlpha | Correct asset-class treatment, quality monitoring, and low-friction interfaces |
+| Chart distribution | MenthorQ and GEXBot | Integrations can be more valuable than another proprietary chart |
+| Polished SPX research | SpotGamma | Category education, habit, and trusted explanation |
+| Broad retail platform | Unusual Whales | Breadth, mobile, and community are a different strategy with different costs |
+| Open/local baseline | GammaGrid | Open, free, local, and replayable are adoption attributes, not a full moat |
 
-The persona lens reuses patterns already developed in adjacent projects:
-advanced ES/NQ futures traders using NinjaTrader and replay, advanced SPY/index
-options users, phone-first novice/prop-evaluation traders, and Python engineers
-who extend one deterministic workflow without private production data. Those
-patterns were adapted to this product rather than treated as validated
-`gex-terminal` customer interviews.
+## Strategic White Space
 
-| Persona | Job to be done | Current fit | Primary blocker | Product priority |
-| --- | --- | ---: | --- | ---: |
-| Quant/model researcher | Inspect assumptions, compare position models, replay controlled sessions, preserve point-in-time provenance | High offline; low empirical | No governed real historical corpus or out-of-sample evidence; the shipped batch surface has only synthetic/offline inputs | Primary |
-| Python/data engineer or contributor | Add licensed feeds, schemas, models, fixtures, exports, and tests without leaking credentials | High | Live validation needs credentials; no stable library/API contract; adapter readiness is uneven | Primary |
-| Advanced ES/NQ futures trader with existing data | Generate fast structural levels, regime context, overlays, and alerts while understanding assumptions | Medium-low | No production-certified live provider, automated integration loop, or measured trading value | Secondary after live certification |
-| Advanced options/volatility trader | Compare GEX with DEX/vanna/charm, flow, term structure, and volatility context | Low-medium | Missing production multi-Greek and flow surfaces; current focus is narrow | Secondary/later |
-| Educator/student | Learn GEX, contract treatment, model differences, and evidence limits without a paid feed | Medium-high | No explicit curriculum; synthetic examples can be mistaken for market evidence | Tertiary |
-| New, mobile-first, or prop-evaluation trader | Receive simple levels, coaching, and account-survival guidance on a phone | Low | Terminal density, setup, no hosted delivery, no validated signal | Deliberate non-target |
+This public scan does not prove that no private or undocumented product covers
+the following areas. It does show a coherent combination that is not common in
+the reviewed positioning.
 
-The primary market should therefore be **quants and developers who value
-control**, with advanced futures traders as the first adjacent user once live
-certification is real. Chasing the novice/mobile audience would pull the product
-toward a crowded hosted-signals business and away from its best assets.
+| White-space capability | Why it matters | Current foundation |
+| --- | --- | --- |
+| Native ES/NQ contract truth | Avoids silently translating cash-index assumptions, multipliers, expiries, basis, and sessions into futures claims | Black-76, per-contract multipliers, normalized futures contracts, separate ES/NQ policies |
+| Visible model dissent | OI, raw volume, and aggressor-directionalized volume answer different questions and should not be blended into one confident line | Three separate models and comparison reports |
+| Provenance on every result | Lets a user distinguish measured input, inferred quantity, configured fallback, and derived proxy | Snapshot, adapter, IV, quality, and model metadata |
+| Live/replay parity | Lets a user inspect the exact state that produced a live conclusion and reproduce it later | Event-time replay, captures, manifests, and corpus identity |
+| Evidence receipts | Creates a complete, chronological record of what the model said and what later happened without converting best excursion into a forecast claim | Journals, price-action evaluation, split contracts, and evidence ceilings |
+| Local/private operation | Fits professionals who cannot send credentials, research inputs, or proprietary experiments to a new hosted vendor | Local application and bring-your-own credentials |
+| Open adapter and model contracts | Allows users to replace a provider or model without abandoning the research record | Separated adapters, consumer, engine, and report modules |
+| A guided operator loop | Converts strong infrastructure into a usable product | Existing TUI, labs, replay browser, exports, and health state need reorganization |
 
-## Product Implications From The Competitive Scan
+The potential moat is a trustworthy history of model/provider behavior across
+real market regimes. Every retained session makes the comparison system more
+useful only if rights, point-in-time identity, and evaluation definitions remain
+governed.
 
-The scan supports four durable decisions:
+## Strategic Implication
 
-1. Certify one ES/NQ provider path before widening provider, symbol, or delivery
-   breadth.
-2. Build licensed, governed point-in-time evidence after certification; model
-   profiles, manifests, corpus contracts, and batch comparisons are now shipped
-   foundations, not remaining feature gaps.
-3. Stabilize a public read-only research interface, then build scanners,
-   integrations, and alerts only on a certified path with visible quality.
-4. Keep broad flow, dark pools, mobile/social, execution, and proprietary
-   commentary outside the core thesis unless persona evidence changes it.
+The evidence supports a narrow professional ES/NQ research instrument rather
+than a broad flow-and-news platform. [Product Vision](product-vision.md) owns
+the selected user, experience, trust contract, and possible product form.
+[ROADMAP.md](../ROADMAP.md) owns the bring-your-own-data hypothesis, the hosted
+tactical-cockpit alternative, and the evidence required to choose between them.
 
-[ROADMAP.md](../ROADMAP.md) is the sole owner of current sequence, status,
-dependencies, and exit criteria. This section records the market evidence's
-implications without maintaining a second delivery checklist.
+## Decisions From This Review
 
-## Decision Gates and Success Evidence
+1. Do not compete on a gamma heatmap, low price, or “for ES/NQ” language.
+2. Turn provenance, model disagreement, data quality, replay, and evidence
+   receipts into visible user workflows rather than backstage machinery.
+3. Validate the research-instrument job and hosted-trader alternative before
+   expanding the feature surface.
+4. Prefer native CME inputs while treating SPX/NDX-derived context as a separate
+   model, not an interchangeable substitute.
+5. Stabilize local research interfaces before REST, MCP, or numerous chart
+   integrations.
+6. Use bring-your-own data for the first commercial experiment unless a written
+   agreement authorizes another model.
+7. Keep higher Greeks, broad equity flow, dark pools, automated trade calls,
+   social/community, and execution outside the initial wedge.
+8. Publish negative and unresolved results. The trust system is more valuable
+   when it can say that the evidence did not support a claim.
 
-| Decision | Evidence required before promotion |
-| --- | --- |
-| Call a live path certified | A saved redacted report covers entitlements, active contracts, chain coverage, OI/IV provenance, timing, reconnects, and failure handling for the exact provider, symbol, environment, and window; any broader claim follows a packet-defined recurrence rule. |
-| Claim model-comparison leadership | A user can replay one governed session through multiple named models and reproduce a versioned diff artifact from the same inputs. |
-| Claim research value | A governed corpus and preregistered evaluation protocol exist; results include null/negative findings and keep predictive validity separate from numerical correctness. |
-| Target active futures traders | The live path, overlay/alert delivery, data-quality visibility, and failure recovery work as one tested workflow. |
-| Add more providers or symbols | The first certified path has stable contracts and comparison metrics; new coverage does not weaken provenance or quality gates. |
-| Claim a price advantage | Total cost of ownership includes app, data entitlement, setup, maintenance, and user time—not the $0 software license alone. |
+[ROADMAP.md](../ROADMAP.md) owns delivery sequence, dependencies, and exit
+criteria. [Product Vision](product-vision.md) owns the durable product shape.
 
 ## Primary Sources
 
-Prices and capabilities were checked August 14, 2026.
+### Market structure and data
 
-- SpotGamma: [plans](https://spotgamma.com/subscribe-to-spotgamma/),
-  [price explanation](https://support.spotgamma.com/hc/en-us/articles/1500002666102-What-is-the-cost-of-a-SpotGamma-Subscription),
-  [GEX methodology](https://spotgamma.com/gamma-exposure-gex/), and
-  [API/export limits](https://support.spotgamma.com/hc/en-us/articles/50266085426195-Does-SpotGamma-have-an-API-Can-I-export-data).
-- MenthorQ: [pricing](https://menthorq.com/pricing/),
-  [coverage](https://menthorq.com/guide/menthorq-asset-coverage/),
-  [gamma levels](https://menthorq.com/guide/key-gamma-levels/), and
-  [integrations](https://menthorq.com/guide/menthorq-trading-integrations/).
-- Barchart: [GEX](https://www.barchart.com/stocks/quotes/AAPL/gamma-exposure)
-  and [membership pricing](https://www.barchart.com/membership-comparison).
-- Unusual Whales: [retail pricing](https://unusualwhales.com/pricing),
-  [API pricing](https://unusualwhales.com/pricing?product=api), and
-  [API documentation](https://api.unusualwhales.com/docs).
-- Quant Data: [API and pricing](https://quantdata.us/api) and
-  [GEX API guide](https://help.quantdata.us/en/articles/15807345-gamma-exposure-gex-api-python-quickstart-dealer-positioning-guide).
+- OCC: [July 2026 volume](https://www.theocc.com/newsroom/views/2026/08-04-july-2026-monthly-volume-report).
+- Cboe: [July 2026 derivatives volume](https://www.cboe.com/insights/posts/market-metrics-that-matter-derivatives-july-2026-volume-highlights),
+  [0DTE market-impact study](https://www.cboe.com/insights/posts/0-dt-es-decoded-positioning-trends-and-market-impact),
+  and [0DTE resources](https://www.cboe.com/tradable-products/0dte/).
+- CME Group: [equity-index options state of play](https://www.cmegroup.com/articles/2025/equity-index-options-state-of-play.html),
+  [Q1 2026 recap](https://www.cmegroup.com/newsletters/quarterly-equity-index-recap/2026-april-equity-index-recap.html),
+  and [options-on-futures resources](https://www.cmegroup.com/markets/options.html).
+- Databento: [options-on-futures introduction](https://databento.com/docs/examples/options/options-on-futures-introduction),
+  [options data](https://databento.com/options), and
+  [pricing](https://databento.com/pricing).
+
+### Products and methods
+
+- Nightglass: [product](https://nightglass.trade/product/),
+  [methodology](https://nightglass.trade/methodology/),
+  [performance](https://nightglass.trade/performance/),
+  [public alert record](https://nightglass.trade/alerts), and
+  [terms](https://nightglass.trade/terms).
+- GammaTape: [product and pricing](https://gammatape.com/) and
+  [method](https://gammatape.com/docs).
 - FlashAlpha: [pricing](https://flashalpha.com/pricing),
-  [API](https://flashalpha.com/api), and
-  [futures/Black-76 documentation](https://flashalpha.com/docs/lab-api-overview).
-- Other premium benchmarks: [TradingFlow](https://tradingflow.com/),
-  [Volland](https://vol.land/pricing),
+  [futures method](https://flashalpha.com/methodology/futures), and
+  [API](https://flashalpha.com/api).
+- GEXBot: [documentation](https://www.gexbot.com/docs),
+  [metrics](https://www.gexbot.com/metrics),
+  [integrations](https://www.gexbot.com/integrations/), and
+  [API](https://www.gexbot.com/apidocs).
+- SpotGamma: [plans](https://spotgamma.com/subscribe-to-spotgamma/),
+  [GEX method](https://spotgamma.com/gamma-exposure-gex/), and
+  [ES workflow](https://support.spotgamma.com/hc/en-us/articles/50270825725203-How-do-I-use-SpotGamma-if-I-trade-ES-E-mini-S-P-500-futures).
+- MenthorQ: [pricing](https://menthorq.com/pricing/),
+  [coverage](https://menthorq.com/guide/menthorq-asset-coverage/), and
+  [integrations](https://menthorq.com/integrations/).
+- OptionsDepth: [pricing](https://optionsdepth.com/pricing) and
+  [FAQ](https://www.optionsdepth.com/faq).
+- Unusual Whales: [retail pricing](https://unusualwhales.com/pricing),
+  [API/MCP](https://unusualwhales.com/public-api), and
+  [live-feed limitations](https://docs.unusualwhales.com/features/flow-status-indicator-live-options-feed/).
+- Quant Data: [dashboard](https://quantdata.us/) and
+  [API](https://quantdata.us/api).
+- Other workflow benchmarks: [Optionomics](https://optionomics.ai/pricing),
+  [TradingFlow](https://tradingflow.com/pricing/),
   [GammaEdge](https://www.gammaedge.com/), and
-  [SqueezeMetrics](https://squeezemetrics.com/monitor/dix).
-- Budget/adjacent benchmarks: [OptionCharts](https://optioncharts.io/pricing),
-  [TradingView](https://www.tradingview.com/pricing/),
-  [thinkorswim](https://www.schwab.com/trading/thinkorswim), and
-  [Cboe delayed quotes](https://www.cboe.com/delayed_quotes/spx/quote_table).
-- Open-source comparators: [GammaGrid](https://github.com/gammagrid/gammagrid),
-  [gex-dashboard](https://github.com/Darthreign/gex-dashboard),
-  [Futures Options S/D Dashboard](https://github.com/Hewkaw02/Futures-Options-SD-Dashboard),
-  [0DTE Dealer Gamma](https://github.com/puneet-chandna/0DTE-dealer-gamma), and
-  [gex-tracker](https://github.com/Matteo-Ferrara/gex-tracker).
+  [SqueezeMetrics](https://squeezemetrics.com/monitor/plans).
+
+### Open and self-hosted comparators
+
+- [GammaGrid](https://github.com/gammagrid/gammagrid)
+- [gex-dashboard](https://github.com/Darthreign/gex-dashboard)
+- [Futures Options S/D Dashboard](https://github.com/Hewkaw02/Futures-Options-SD-Dashboard)
+- [0DTE Dealer Gamma](https://github.com/puneet-chandna/0DTE-dealer-gamma)

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -1,83 +1,182 @@
 # Product Vision
 
-`gex-terminal` is an open, local-first market-structure research workbench for
-people who want to inspect how a GEX estimate was produced. It is not trying to
-be a cheaper clone of a closed dashboard. Its durable advantage should come
-from provider-normalized inputs, replaceable models, reproducible point-in-time
-research, and explicit evidence ceilings.
+`gex-terminal` should become the auditable, local-first market-structure
+instrument for ES/NQ options research. Its purpose is not to produce one more
+confident gamma line. Its purpose is to let a user understand what produced a
+structural proxy, where credible models disagree, whether the source is healthy,
+and what later evidence did or did not support the original read.
 
 Implementation status and sequencing belong in [ROADMAP.md](../ROADMAP.md).
-Shipped history belongs in [CHANGELOG.md](../CHANGELOG.md).
+Shipped history belongs in [CHANGELOG.md](../CHANGELOG.md). Market facts and
+competitive conclusions belong in
+[Competitive Landscape](market-analysis.md).
 
-## Product Promise
+## North Star
 
-A researcher should be able to answer:
+> Show me the current structural proxy, tell me exactly why it looks that way,
+> show where credible models disagree, and let me replay the same state later.
 
-- Which provider records and position quantity produced this view?
-- Which pricing model, expiry, multiplier, rate, and IV provenance were used?
-- How would the result change under another explicit position model?
-- Can another person replay the same point-in-time inputs and reproduce it?
-- What does the evidence establish, and what remains unobserved or unmeasured?
+The durable product promise is **inspectability before interpretation**. Every
+important output should answer:
 
-The workbench should make those answers easier without requiring a hosted
-account or hiding calculations behind a proprietary interface.
+- Which provider records, contracts, timestamps, and quantities produced it?
+- Which pricing model, expiry, multiplier, rate, IV source, and position model
+  were applied?
+- Which parts are observed, inferred, configured, or derived?
+- Do other credible position models agree?
+- Is the source complete and fresh enough for this exact claim?
+- Can another person reproduce the result from the same point-in-time inputs?
+- What did later evidence show, and what remains unmeasured?
 
-## Primary Users
+## Initial Target Hypothesis And Job
 
-- **Quant and model researchers** comparing assumptions, providers, sessions,
-  and outcomes.
-- **Python and data engineers** extending normalized adapters and reproducible
-  research contracts.
-- **Advanced ES/NQ traders** studying transparent structural proxies after a
-  live data path has met its declared certification gate.
+The initial target is one behavioral segment: a technically capable ES/NQ
+research operator who owns the data relationship and personally tests or uses
+structural models. That person may work as a quant, developer, researcher, or
+advanced trader, but the common behavior—not the job title—is the hypothesis.
+Phase 0 of the [roadmap](../ROADMAP.md) must validate or replace it before it is
+treated as a confirmed market.
 
-Mobile-first novices, commentary-seeking traders, and users seeking automatic
-trade execution are not the primary product target.
+Their recurring job is not “tell me where price will go.” It is:
+
+> Help me form, inspect, preserve, and later evaluate a model-dependent view of
+> options market structure without hiding data quality or turning a proxy into
+> observed dealer inventory.
+
+Less-technical advanced futures traders are the first adjacent audience when a
+live path has a defined support envelope. The buying unit and willingness to
+pay remain open questions. Mobile-first novices, commentary-seeking traders,
+and users seeking automatic execution are not the first target.
+
+## The Real Product Experience
+
+The application should feel like one research loop rather than a collection of
+commands.
+
+### Today
+
+Start with a source preflight: entitlement state, active contract, chain
+coverage, freshness, OI state, IV provenance, and any degraded inputs. Then show
+the current proxy regime, dominant structures, and material changes with a
+visible proof ceiling.
+
+### Explain
+
+Let the user open any wall, flip, exposure band, or alert and trace it back to
+the contracts and assumptions that produced it. Explain the mechanical model
+without claiming that the model observed participant identity, intent, or a
+future outcome.
+
+### Compare
+
+Run identical point-in-time inputs through open interest, raw volume,
+directionalized volume, and future licensed attribution methods without adding
+or relabeling unlike quantities. Make agreement, disagreement, coverage, and
+uncertainty more prominent than a single composite score.
+
+### Replay
+
+Replay the exact event-time session, not a reconstructed screenshot. Preserve
+source identity, model version, parameter changes, quality transitions, and the
+conclusion that was available at each point in time.
+
+### Review
+
+Bind a saved read to later descriptive and outcome evidence. Keep favorable
+excursion, adverse excursion, fixed-horizon movement, executable assumptions,
+costs, and realized account returns separate. Retain negative, unresolved, and
+failed-source cases alongside successes.
 
 ## Signature Outcomes
 
-### Inspectable Proxy Regime View
+### Inspectable Regime View
 
-Present the selected position model's positive or negative exposure proxy,
-documented strike-profile compatibility level, gamma-wall concentration, spot,
-and next structural trigger in one compact view. Volatility, pinning, support,
-and resistance interpretations remain hypotheses for evaluation rather than
-observed dealer behavior.
+Present the selected model's positive or negative exposure proxy, strike
+profile, concentration, spot, quality state, and next structural change in one
+compact surface. Volatility, pinning, support, resistance, and acceleration
+remain hypotheses to evaluate rather than observed dealer behavior.
+
+### Model-Dissent Map
+
+Show where position models agree on sign, walls, ranks, and change—and where
+they do not. The product should be most useful on ambiguous days because it can
+explain why confidence is limited.
 
 ### Replayable Market Days
 
-Let researchers preserve a governed point-in-time session, replay it on its
-event-time clock, compare walls and profile changes, and bind the result to its
-input identity and model profile. In-file consistency hashes detect corruption;
-source rights, authenticity, and historical immutability require separate
-authority.
+Preserve governed point-in-time sessions, replay them on their event-time
+clock, and bind results to input, provider, policy, and model identities.
+Consistency hashes can detect corruption; source rights, authenticity, and
+historical immutability require separate authority.
 
 ### Portable Levels And Local Alerts
 
-Make derived levels, exposure bands, quality states, and structural changes
-portable to local files and user-owned tools. Every export or alert should
-retain enough provider, model, timing, and readiness provenance to avoid turning
-a proxy into an unexplained signal.
+Make derived levels, exposure bands, quality changes, and model-dissent events
+portable to user-owned tools. Every export or alert should retain enough
+provider, model, timing, and readiness provenance to remain interpretable away
+from the application.
 
-### Comparable Position Models
+### Evidence Vault
 
-Replay identical sessions through open interest, raw trade volume,
-directionalized trade volume, and any future licensed participant-attribution
-method without adding or relabeling unlike quantities. Comparison should expose
-coverage and disagreement before attempting to score predictive value.
+Build a governed history of sessions, experiments, model versions, and results
+that can be reproduced on a clean machine. Its value is an honest record of
+where models were stable, unstable, descriptive, useful, or unsupported—not a
+curated gallery of wins.
 
-### Cross-Symbol Research
+### Developer Surface
 
-Allow comparable ES/NQ and related-symbol study only where each provider path
-can show contract coverage, freshness, provenance, and quality. A scanner should
-rank modeled structural change, not imply dealer inventory or forecast risk
-that the inputs do not observe.
+Offer stable read-only domain objects and artifact contracts so providers,
+models, research notebooks, local services, and integrations can reuse the
+same semantics. External interfaces must not create a second, less-governed
+definition of the data or model.
+
+## Product Form
+
+The durable shape is an open research kernel surrounded by optional convenience
+and operational layers:
+
+- **Open Lab:** deterministic demo/replay, transparent calculations,
+  contributor adapters, model comparison, and local artifacts.
+- **Professional Desktop:** packaged installation, guided bring-your-own-data
+  setup, certified live workflows, background operation, alerts, integrations,
+  upgrades, diagnostics, and support.
+- **Research Team:** rights-aware derived-artifact sharing, governed experiment
+  and corpus controls, reproducible comparisons, and administrative support.
+
+This is a product hypothesis, not a commitment to specific packaging or
+pricing. The open MIT kernel should remain useful on its own. Any paid layer
+must sell convenience, operational confidence, collaboration, or support—not
+obscure the calculation that creates trust.
+
+An optional hosted service is compatible with the vision only when data rights,
+privacy, support, and economics are explicit. Local operation and bring-your-own
+credentials remain the default posture. Raw licensed market data must not be
+centralized or redistributed merely because derived collaboration is useful.
+
+## Trust Contract
+
+- Provider readiness, runtime connection state, input quality, numerical
+  correctness, descriptive usefulness, predictive validity, execution quality,
+  and profitability remain separate claims.
+- No output implies dealer/customer identity, opening/closing activity, or
+  institutional intent unless licensed fields establish it.
+- No live connection certifies a provider; no fixture certifies a live path;
+  no backtest certifies executable performance.
+- Source gaps and model disagreement remain visible. Missing evidence is not
+  converted to zero or hidden behind a confidence badge.
+- Evaluation definitions are fixed before outcomes are inspected. Complete
+  eligible populations and null findings remain available.
+- User credentials, raw licensed data, and private research stay local unless a
+  separate, explicit agreement authorizes another path.
 
 ## Product Boundaries
 
-The product does not infer dealer/customer identity, opening/closing activity,
-or institutional intent without licensed fields that supply those facts. It
-does not treat a live connection as provider certification, offline correctness
-as predictive validation, or a backtest as executable performance. Broad
-options flow, dark pools, social/mobile delivery, execution, and proprietary
-commentary remain outside the core thesis unless user evidence changes it.
+Broad equity-options flow, dark pools, political data, news aggregation,
+social/community feeds, automated trade calls, brokerage execution, and generic
+AI commentary are not part of the core thesis. Higher Greeks, multi-asset
+coverage, hosted delivery, and an evidence-aware assistant are possible
+extensions only when the primary workflow, data rights, and user demand support
+them.
+
+The product should not win by sounding more certain than the evidence. It
+should win by making uncertainty inspectable and useful.


### PR DESCRIPTION
Summary
- refresh the September 2026 competitive landscape, including Nightglass, GammaTape, FlashAlpha, industry growth, and the challenge to simplistic GEX causality
- define the durable real-product experience without expanding the README or current architecture
- replace the live-only roadmap with gated customer, distribution, certification, beta, evidence, commercial, and expansion phases
- keep the local professional product as the lead hypothesis while giving the hosted alternative one explicit evidence-based decision path

Verification
- 297 unit tests pass
- documentation link contract passes
- git diff whitespace check passes
- independent documentation review found no remaining priority findings