### PR TITLE
fix: settle replay writer before replacing session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ claimed.
 
 ### Fixed
 
+- Replay selection now settles the previous CLI writer before resetting state;
+  active fixed-delay/event-clock streams cannot contaminate a replacement
+  session. Failed writers block replacement and remain visible at shutdown.
+
 - Bound bundled replay workflows to catalog instrument identity and rejected
   unsupported symbol labels on the seeded ES demo. Snapshot exports now
   distinguish the configured fallback multiplier from actual selected-contract

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,8 +7,8 @@ This file contains planned and deferred work only. Shipped work belongs in
 belongs in [Competitive Landscape](docs/market-analysis.md).
 
 Priorities reviewed September 4, 2026 against application version `0.4.0`.
-The instrument-identity repair is routed under `GEX-HEALTH-001`; remaining
-correctness work is H2–H5, followed by offline preflight. The phases below remain
+Remaining correctness work is H2 configuration/health, H4 experiment identity,
+and H5 accepted-event chronology, followed by offline preflight. The phases below remain
 conditional plans. [Application Review](docs/application-review.md) owns the
 dated health evidence and open findings.
 
@@ -21,7 +21,7 @@ an accepted work packet owns implementation status.
 
 | Order | Work | Why now | Completion evidence |
 | --- | --- | --- | --- |
-| 1 — Correctness | Close H2–H5: configuration/health, replay isolation, experiment identity, and accepted-event chronology | A useful product must preserve the identity and validity of the result before adding delivery features | Each accepted finding has a minimal reproduction, a focused regression, and an explicit rejection or correct result through the public workflow |
+| 1 — Correctness | Close H2, H4, and H5: configuration/health, experiment identity, and accepted-event chronology | A useful product must preserve the identity and validity of the result before adding delivery features | Each accepted finding has a minimal reproduction, a focused regression, and an explicit rejection or correct result through the public workflow |
 | 2 — Offline preflight | Add an offline `doctor` command and repair any demonstrated install/configuration failures | Users and contributors need to distinguish a broken environment from an unsupported provider | Text/JSON diagnostics work from an installed wheel outside the checkout; invalid base configuration fails; absent optional providers are explained; no connection or secret disclosure occurs |
 | 3 — Complete one research loop | Extend the existing Demo Lab with model comparison and a reproducible review receipt; add a synthetic NQ fixture where needed | Existing replay, export, journal, and experiment tools already provide most of the machinery | One authorized session yields a portable pack with source/model/quality identity, separated position models, and a reproducible result |
 | 4 — Make it usable on a fresh machine | Deliver one guided install and replay journey for the first user segment | Observed activation matters more than another command or panel | One selected distribution path passes install/upgrade checks and users complete the scoped journey without developer help |
@@ -564,8 +564,7 @@ phase uses them as a gate.
 
 ## Immediate Continuation Point
 
-After the `GEX-HEALTH-001` identity slice closes, route H2 health/configuration,
-H3 replay lifecycle, H4 experiment identity, and H5 event chronology as separate
+Finish H2 health/configuration, H4 experiment identity, and H5 event chronology as separate
 bounded repair slices with their own reproductions and regressions. Finish
 this correctness sequence before extending the affected research workflows.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,8 +28,10 @@ status checklists into multiple files.
 
 An active work packet under `work-packets/` owns the status of its authorized
 change. Closed packets are historical evidence and do not make a roadmap item
-active. [GEX-HEALTH-001](work-packets/GEX-HEALTH-001.md) owns the current
-instrument-identity repair slice.
+active. [GEX-HEALTH-003](work-packets/GEX-HEALTH-003.md) owns replay-lifecycle
+repair; independent configuration and experiment repairs are isolated on their
+own contributor branches. [GEX-HEALTH-001](work-packets/GEX-HEALTH-001.md)
+records the merged instrument-identity repair.
 
 ## Start Here By Goal
 

--- a/docs/SAED_ADOPTION_PROFILE.md
+++ b/docs/SAED_ADOPTION_PROFILE.md
@@ -18,8 +18,9 @@
 
 **Adopted:** 2026-08-19
 
-**Status owner:** `GEX-HEALTH-001` owns the active instrument-identity slice;
-closed packet `GEX-LIVE-001` records the `0.4.0` repository release
+**Status owner:** Each routed contributor packet owns its bounded slice;
+`GEX-HEALTH-003` owns replay lifecycle, and `GEX-HEALTH-001` records the merged
+identity repair. Closed `GEX-LIVE-001` records the `0.4.0` repository release.
 
 ## Purpose And Entry Boundary
 

--- a/docs/application-review.md
+++ b/docs/application-review.md
@@ -115,7 +115,14 @@ Reject invalid timing, rate, multiplier, and expiry values with an actionable
 error. A stale source must never become healthy because of an invalid setting.
 Keep intentionally optional values distinct from malformed ones.
 
-### H3 — P1: Switching replay can leave the previous stream writing state
+### H3 — Resolved: Replay replacement settles the previous writer
+
+Repair: the CLI passes its writer task to the terminal, which serializes
+replacement and cancels/awaits the old source before reset. Fixed-delay and
+event-clock tests exercise the full CLI-to-interactive path and prove an old-only
+strike cannot enter the new session. A failed writer blocks replacement and is
+reported at shutdown. [GEX-HEALTH-003](work-packets/GEX-HEALTH-003.md) owns the
+repair evidence. The following records the original defect.
 
 The interactive CLI starts an adapter task in
 [`cli.py`](../gex_terminal/cli.py), while the TUI's

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,9 +230,12 @@ owns:
 - provider and feed-quality counters
 - subscription and entitlement status
 
-Use `reset_state(...)` before loading a new offline session into an existing
-terminal app. That clears market data and quality counters behind the same lock
-used by live updates.
+The CLI gives the terminal ownership of its active replay writer task. Replay
+replacement is serialized and cancels/awaits that writer before calling
+`reset_state(...)`; only after adapter cleanup may new input enter. A failed
+writer blocks replacement and remains visible at CLI shutdown. Reset clears
+market data and quality counters behind the same lock used by updates. Capture
+and live-source sessions cannot switch replay.
 
 ## Contributor Boundaries
 

--- a/docs/work-packets/GEX-HEALTH-001.md
+++ b/docs/work-packets/GEX-HEALTH-001.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: merged; clean-main verification pending
+status: closed
 packet_owner: project maintainer
 spec_steward: implementation agent
 evidence_reviewer: pull-request reviewer and hosted CI
@@ -67,4 +67,5 @@ implementation; no stored artifacts are migrated or overwritten.
   cases are covered by public-workflow tests.
 - [PR #20](https://github.com/zrack/gex-terminal/pull/20) passed all four
   Python 3.11/3.12 hosted checks, including installed-wheel smoke, and merged.
-  Clean-main verification is recorded at the next integration boundary.
+  Clean main at `e613e26387549a34c74a836bc885683ee8008c74` passed all 314
+  tests and source compilation with no local changes.

--- a/docs/work-packets/GEX-HEALTH-001.md
+++ b/docs/work-packets/GEX-HEALTH-001.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: ready for contributor review
+status: merged; clean-main verification pending
 packet_owner: project maintainer
 spec_steward: implementation agent
 evidence_reviewer: pull-request reviewer and hosted CI
@@ -65,4 +65,6 @@ implementation; no stored artifacts are migrated or overwritten.
 - Public SPY fixture export records effective multiplier 100 and configured
   fallback 50. ES/NQ demo, selected replay, screenshot, and saved-store identity
   cases are covered by public-workflow tests.
-- Hosted checks and merged-main verification remain pending at this commit.
+- [PR #20](https://github.com/zrack/gex-terminal/pull/20) passed all four
+  Python 3.11/3.12 hosted checks, including installed-wheel smoke, and merged.
+  Clean-main verification is recorded at the next integration boundary.

--- a/docs/work-packets/GEX-HEALTH-003.md
+++ b/docs/work-packets/GEX-HEALTH-003.md
@@ -1,0 +1,42 @@
+# GEX-HEALTH-003 — Replay Writer Ownership
+
+```yaml
+method: saed
+method_version: "1.3"
+profile: gex-terminal-team-v1
+change_rigor: L3
+status: ready for contributor review
+packet_owner: project maintainer
+baseline: 4d58f89
+branch: codex/gex-health-003-replay-ownership
+created: 2026-09-04
+```
+
+The maintainer's September 4 offline-work authorization includes H3. Preserve
+INV-01 through INV-08: consumer remains sole market-state owner, and switching
+session must never mix sources. No live data or new provider is in scope.
+
+## Acceptance and design
+
+The CLI passes the active writer task to the terminal. A replay transition is
+serialized; it validates the new input, cancels and awaits the previous writer,
+and only then changes configuration or resets state. A failed old writer blocks
+replacement and is still reported at CLI shutdown. Capture and live modes
+cannot switch. Cancellation must settle adapter cleanup before new data enters.
+
+Public CLI regressions exercise active fixed-delay and event-clock streams,
+switch through the terminal, and prove no old-only strike reaches replacement
+state. Existing idle-switch and capture/shutdown tests must continue passing.
+
+## Verification and recovery
+
+Focused lifecycle tests, full regression, compileall, diff hygiene, independent
+review, hosted checks, contributor merge, and clean-main regression. Revert the
+merge to recover prior behavior; no artifact migration occurs.
+
+## Evidence
+
+- 19 focused replay/terminal/capture tests passed, including full CLI ownership
+  regressions for both replay clocks and failed-source preservation.
+- All 316 tests, source compilation, and diff hygiene passed on the branch.
+- Hosted checks and clean merged-main verification remain pending.

--- a/gex_terminal/cli.py
+++ b/gex_terminal/cli.py
@@ -381,6 +381,7 @@ async def main():
         consumer=state_consumer,
         config=config,
         allow_replay_switching=capture_writer is None,
+        source_task=stream_task,
     )
     app_failed = False
     try:

--- a/gex_terminal/tui.py
+++ b/gex_terminal/tui.py
@@ -64,11 +64,14 @@ class GexTerminalApp(App):
         config: GexConfig | None = None,
         *,
         allow_replay_switching: bool = True,
+        source_task: asyncio.Task | None = None,
     ):
         super().__init__()
         self.consumer = consumer
         self.config = config or GexConfig.from_env()
         self.allow_replay_switching = bool(allow_replay_switching)
+        self._source_task = source_task
+        self._replay_transition_lock = asyncio.Lock()
         self._gex_flow: deque[float] = deque(maxlen=36)
         self._latencies: deque[float] = deque(maxlen=36)
         self._events: deque[str] = deque(maxlen=7)
@@ -288,8 +291,16 @@ class GexTerminalApp(App):
         self._render_events()
 
     async def _load_replay_session(self, session: ReplaySession) -> None:
+        async with self._replay_transition_lock:
+            await self._replace_replay_session(session)
+
+    async def _replace_replay_session(self, session: ReplaySession) -> None:
         if not self.allow_replay_switching:
             self._event("replay load blocked -> active session capture")
+            self._render_events()
+            return
+        if self.config.data_mode.lower() not in {"demo", "replay"}:
+            self._event("replay load blocked -> live source owns this session")
             self._render_events()
             return
         try:
@@ -300,6 +311,20 @@ class GexTerminalApp(App):
             return
 
         replay_config = config_for_replay_session(self.config, session)
+        if self._source_task is not None:
+            self._source_task.cancel()
+            try:
+                await self._source_task
+            except asyncio.CancelledError:
+                # Only a settled writer may be replaced. Caller cancellation
+                # must still propagate, rather than resetting state on exit.
+                if asyncio.current_task().cancelling():
+                    raise
+            except Exception:
+                self._event("replay load blocked -> previous source failed; restart the session")
+                self._render_events()
+                return
+            self._source_task = None
         self.config = replace(
             replay_config,
             replay_delay_seconds=0.0,

--- a/tests/test_replay_ownership.py
+++ b/tests/test_replay_ownership.py
@@ -1,0 +1,95 @@
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from gex_terminal import cli
+from gex_terminal.adapters.replay import ReplayAdapter
+from gex_terminal.replay_catalog import replay_session_for_name
+from gex_terminal.tui import GexTerminalApp
+
+
+class ReplayOwnershipTests(unittest.IsolatedAsyncioTestCase):
+    async def test_cli_settles_old_writer_before_interactive_replacement(self):
+        for clock in ("fixed", "event"):
+            with self.subTest(clock=clock), tempfile.TemporaryDirectory() as directory:
+                source = Path(directory) / "old.jsonl"
+                messages = [
+                    {"type": "underlying_tick", "symbol": "ES", "price": 5950,
+                     "timestamp": "2026-08-01T14:00:00Z"},
+                    {"type": "options_volume_tick", "strike": 5950, "option_type": "C",
+                     "volume": 10, "iv": .2, "timestamp": "2026-08-01T14:00:01Z"},
+                    {"type": "options_volume_tick", "strike": 9999, "option_type": "C",
+                     "volume": 10, "iv": .2, "timestamp": "2026-08-01T14:00:02Z"},
+                ]
+                source.write_text("\n".join(json.dumps(message) for message in messages))
+                old_writer_waiting = asyncio.Event()
+                never_released = asyncio.Event()
+                observed = {}
+
+                def build_adapter(consumer, config):
+                    async def controlled_sleep(delay):
+                        if consumer.message_count == 2:
+                            old_writer_waiting.set()
+                            await never_released.wait()
+                        await asyncio.sleep(0)
+                    return ReplayAdapter(
+                        consumer, config.replay_path, delay_seconds=.1,
+                        replay_clock=clock, sleep=controlled_sleep,
+                    )
+
+                async def interactive_run(app):
+                    async with app.run_test(size=(160, 48)):
+                        await asyncio.wait_for(old_writer_waiting.wait(), 3)
+                        previous_writer = app._source_task
+                        self.assertIsNotNone(previous_writer)
+                        self.assertFalse(previous_writer.done())
+                        await app.action_cycle_replay_session()
+                        app._replay_browser_index = app._session_index(
+                            replay_session_for_name("zero-gamma-flip")
+                        )
+                        await app.action_select_replay_session()
+                        self.assertTrue(previous_writer.cancelled())
+                        self.assertIsNone(app._source_task)
+                        self.assertNotIn(9999, app.consumer.chain_state)
+                        count = app.consumer.message_count
+                        never_released.set()
+                        await asyncio.sleep(0)
+                        self.assertEqual(app.consumer.message_count, count)
+                        self.assertNotIn(9999, app.consumer.chain_state)
+                        observed["session"] = app._active_replay_session.name
+
+                environment = {key: value for key, value in os.environ.items()
+                               if not key.startswith("GEX_")}
+                with patch.dict(os.environ, environment, clear=True), patch.object(
+                    sys, "argv", ["gex-terminal", "--replay", str(source), "--replay-clock", clock]
+                ), patch.object(cli, "build_market_data_adapter", side_effect=build_adapter), patch.object(
+                    GexTerminalApp, "run_async", interactive_run
+                ):
+                    await cli.main()
+                self.assertEqual(observed["session"], "zero-gamma-flip")
+
+    async def test_failed_source_blocks_reset_and_preserves_error(self):
+        from tests.test_tui_first_run import _config
+        from gex_terminal.consumer import StatefulGexConsumer
+        from gex_terminal.engine import IntradayGexEngine
+
+        async def broken_source():
+            raise ValueError("source failed")
+
+        writer = asyncio.create_task(broken_source())
+        await asyncio.sleep(0)
+        consumer = StatefulGexConsumer(IntradayGexEngine(), data_mode="replay")
+        consumer.current_spot = 123
+        app = GexTerminalApp(consumer, _config("replay"), source_task=writer)
+        async with app.run_test(size=(160, 48)):
+            await app._load_replay_session(replay_session_for_name("trend-day"))
+        self.assertEqual(consumer.current_spot, 123)
+        self.assertIs(app._source_task, writer)
+        errors = await cli._shutdown_runtime_tasks(writer, None, None, consumer, run_failed=False)
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], ValueError)


### PR DESCRIPTION
## Outcome

Close H3 replay contamination through explicit writer ownership. The CLI passes its source task into the terminal; switching serializes transitions, validates inputs, cancels/awaits the old writer and only then resets consumer state. Failed writers prevent replacement and still surface at shutdown. Live/capture switching stays prohibited.

## Verification

316 tests, compileall and diff hygiene passed. Public CLI-to-terminal regressions exercise delayed and event-clock replay, verify the old task settles before replacement, and assert its unique strike never arrives afterward. Failed-source regression preserves the shutdown error.

Docs reconcile current ownership, finding status, and the earlier H1 merge. No live data or readiness promotion.
