### PR TITLE
fix: derive replay chronology from accepted market state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ claimed.
 
 ### Fixed
 
+- Replay reports now create analytical transitions only for accepted consumer
+  updates, align snapshot time with model as-of, and separate raw input audit
+  timestamps from accepted-state chronology. Untimed input is explicitly
+  processing-time evidence, not observed market time.
+
 - Replay selection now settles the previous CLI writer before resetting state;
   active fixed-delay/event-clock streams cannot contaminate a replacement
   session. Failed writers block replacement and remain visible at shutdown.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,8 +7,8 @@ This file contains planned and deferred work only. Shipped work belongs in
 belongs in [Competitive Landscape](docs/market-analysis.md).
 
 Priorities reviewed September 4, 2026 against application version `0.4.0`.
-Remaining correctness work is H2 configuration/health, H4 experiment identity,
-and H5 accepted-event chronology, followed by offline preflight. The phases below remain
+Remaining correctness work is H2 configuration/health and H4 experiment
+identity, followed by offline preflight. The phases below remain
 conditional plans. [Application Review](docs/application-review.md) owns the
 dated health evidence and open findings.
 
@@ -21,7 +21,7 @@ an accepted work packet owns implementation status.
 
 | Order | Work | Why now | Completion evidence |
 | --- | --- | --- | --- |
-| 1 — Correctness | Close H2, H4, and H5: configuration/health, experiment identity, and accepted-event chronology | A useful product must preserve the identity and validity of the result before adding delivery features | Each accepted finding has a minimal reproduction, a focused regression, and an explicit rejection or correct result through the public workflow |
+| 1 — Correctness | Close H2 and H4: configuration/health and experiment identity | A useful product must preserve the identity and validity of the result before adding delivery features | Each accepted finding has a minimal reproduction, a focused regression, and an explicit rejection or correct result through the public workflow |
 | 2 — Offline preflight | Add an offline `doctor` command and repair any demonstrated install/configuration failures | Users and contributors need to distinguish a broken environment from an unsupported provider | Text/JSON diagnostics work from an installed wheel outside the checkout; invalid base configuration fails; absent optional providers are explained; no connection or secret disclosure occurs |
 | 3 — Complete one research loop | Extend the existing Demo Lab with model comparison and a reproducible review receipt; add a synthetic NQ fixture where needed | Existing replay, export, journal, and experiment tools already provide most of the machinery | One authorized session yields a portable pack with source/model/quality identity, separated position models, and a reproducible result |
 | 4 — Make it usable on a fresh machine | Deliver one guided install and replay journey for the first user segment | Observed activation matters more than another command or panel | One selected distribution path passes install/upgrade checks and users complete the scoped journey without developer help |
@@ -564,7 +564,7 @@ phase uses them as a gate.
 
 ## Immediate Continuation Point
 
-Finish H2 health/configuration, H4 experiment identity, and H5 event chronology as separate
+Finish H2 health/configuration and H4 experiment identity as separate
 bounded repair slices with their own reproductions and regressions. Finish
 this correctness sequence before extending the affected research workflows.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,10 +28,10 @@ status checklists into multiple files.
 
 An active work packet under `work-packets/` owns the status of its authorized
 change. Closed packets are historical evidence and do not make a roadmap item
-active. [GEX-HEALTH-003](work-packets/GEX-HEALTH-003.md) owns replay-lifecycle
-repair; independent configuration and experiment repairs are isolated on their
-own contributor branches. [GEX-HEALTH-001](work-packets/GEX-HEALTH-001.md)
-records the merged instrument-identity repair.
+active. [GEX-HEALTH-005](work-packets/GEX-HEALTH-005.md) owns accepted-event
+chronology; independent configuration, experiment, and research-loop slices
+are isolated on their contributor branches. Merged identity and replay-lifecycle
+repairs are recorded in `GEX-HEALTH-001` and `GEX-HEALTH-003`.
 
 ## Start Here By Goal
 

--- a/docs/SAED_ADOPTION_PROFILE.md
+++ b/docs/SAED_ADOPTION_PROFILE.md
@@ -19,8 +19,8 @@
 **Adopted:** 2026-08-19
 
 **Status owner:** Each routed contributor packet owns its bounded slice;
-`GEX-HEALTH-003` owns replay lifecycle, and `GEX-HEALTH-001` records the merged
-identity repair. Closed `GEX-LIVE-001` records the `0.4.0` repository release.
+`GEX-HEALTH-005` owns chronology, and `GEX-HEALTH-001`/`003` record merged
+repairs. Closed `GEX-LIVE-001` records the `0.4.0` repository release.
 
 ## Purpose And Entry Boundary
 

--- a/docs/application-review.md
+++ b/docs/application-review.md
@@ -163,7 +163,14 @@ identity. Test profile, split, outcome, cost, and implementation compatibility
 independently from input/result parity. These checks establish internal
 consistency; authenticity still requires separate signed or anchored evidence.
 
-### H5 — P1: Dropped events can advance replay report timestamps
+### H5 — Resolved: Replay chronology follows accepted state
+
+Repair: consumer updates return explicit acceptance. Replay reports skip
+analytical points for rejected input, retain a separate raw-input audit, and
+align snapshot time with model as-of. Regressions cover off-symbol, malformed,
+duplicate, conflicting-identity and regressed-time records, untimed legacy
+labels, and journal persistence. [GEX-HEALTH-005](work-packets/GEX-HEALTH-005.md)
+owns verification. The following describes the original defect.
 
 [`analyze_replay_session`](../gex_terminal/replay_lab.py) records incoming
 metadata before consumer validation and creates a timeline point after each

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,6 +184,9 @@ five paths:
   integrity-checked captures enter through replay adapters and event-time
   controls. A capture cannot switch replay streams mid-file. Live capture
   additionally passes the capture-policy gate before provider startup.
+  Consumer acceptance determines analytical timeline membership; rejected input
+  remains only in counters/raw-input audit. Snapshot as-of follows accepted
+  state, not the final raw record's timestamp.
 - **Provider-shaped intake:** provider injection, fixture labs, and offline
   Databento certification reuse production mapping without opening a live
   connection or promoting readiness.

--- a/docs/exports.md
+++ b/docs/exports.md
@@ -117,6 +117,15 @@ Captured-session JSONL is an event artifact rather than a snapshot report. See
 
 ## Replay Lab Reports
 
+Analytical timeline points are emitted only for accepted consumer updates.
+`timestamp` is model-state as-of; `input_event_time` records that accepted
+input's own time (which can regress while sequence is preserved). Snapshot
+timestamp equals `model.as_of`. `raw_input_audit` keeps incoming metadata and
+counts separately; dropped, malformed, duplicate, or conflicting input cannot
+advance analytical time or generate a model transition. Untimed legacy input
+is labeled `processing_time`, never observed market time. Journal entries
+preserve this separation without rewriting older saved artifacts.
+
 Replay Lab reports run one or more bundled synthetic sessions and export a
 research artifact:
 

--- a/docs/work-packets/GEX-HEALTH-003.md
+++ b/docs/work-packets/GEX-HEALTH-003.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: merged; clean-main verification pending
+status: closed
 packet_owner: project maintainer
 baseline: 4d58f89
 branch: codex/gex-health-003-replay-ownership
@@ -41,4 +41,4 @@ merge to recover prior behavior; no artifact migration occurs.
 - All 316 tests, source compilation, and diff hygiene passed on the branch.
 - [PR #21](https://github.com/zrack/gex-terminal/pull/21) passed all four hosted
   Python 3.11/3.12 checks and merged as `ba6319203f41f47b549f3637d792cf1f3daed57a`.
-  Clean-main verification is recorded at the next integration boundary.
+  Clean main at that merge passed all 316 tests and compilation with no changes.

--- a/docs/work-packets/GEX-HEALTH-003.md
+++ b/docs/work-packets/GEX-HEALTH-003.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: ready for contributor review
+status: merged; clean-main verification pending
 packet_owner: project maintainer
 baseline: 4d58f89
 branch: codex/gex-health-003-replay-ownership
@@ -39,4 +39,6 @@ merge to recover prior behavior; no artifact migration occurs.
 - 19 focused replay/terminal/capture tests passed, including full CLI ownership
   regressions for both replay clocks and failed-source preservation.
 - All 316 tests, source compilation, and diff hygiene passed on the branch.
-- Hosted checks and clean merged-main verification remain pending.
+- [PR #21](https://github.com/zrack/gex-terminal/pull/21) passed all four hosted
+  Python 3.11/3.12 checks and merged as `ba6319203f41f47b549f3637d792cf1f3daed57a`.
+  Clean-main verification is recorded at the next integration boundary.

--- a/docs/work-packets/GEX-HEALTH-005.md
+++ b/docs/work-packets/GEX-HEALTH-005.md
@@ -1,0 +1,43 @@
+# GEX-HEALTH-005 — Accepted-Event Chronology
+
+```yaml
+method: saed
+method_version: "1.3"
+profile: gex-terminal-team-v1
+change_rigor: L3
+status: ready for contributor review
+packet_owner: project maintainer
+branch: codex/gex-health-005-accepted-chronology
+created: 2026-09-04
+```
+
+Authorized by the September 4 offline-correctness request. Preserve INV-01
+through INV-08, especially consumer state ownership and point-in-time evidence.
+No live observation or predictive claim is in scope.
+
+## Contract and acceptance
+
+- Consumer updates explicitly return accepted/rejected status; existing callers
+  may ignore it. Malformed, off-symbol, duplicate, and identity-conflicting
+  records cannot create analytical transitions.
+- Replay reports separate raw input audit timestamps/phases/count from accepted
+  state time. Snapshot timestamp equals model as-of. Timeline points retain the
+  accepted input index/time separately from the monotonic model-state time.
+- Untimed legacy input cannot claim an observed market time: expose processing
+  time as such. Raw quality annotations remain diagnostic, not state transitions.
+- Regressions append late rejected records after valid state and cover downstream
+  journal persistence and report formats. Valid behavior remains unchanged.
+
+## Verification and recovery
+
+Run focused consumer/replay/journal tests, full regression, compileall, numerical
+evidence and diff checks; await hosted checks, merge and verify clean main.
+Revert the merge for code recovery. Existing artifacts are not rewritten.
+
+## Evidence
+
+- 32 focused consumer/replay/journal tests passed. New regressions explicitly
+  separate late rejected input from model time and persist that boundary through
+  the journal workflow.
+- All 320 tests, compileall, diff hygiene and numerical model evidence passed.
+- Hosted checks and clean merged-main verification remain pending.

--- a/gex_terminal/consumer.py
+++ b/gex_terminal/consumer.py
@@ -235,13 +235,14 @@ class StatefulGexConsumer:
         snapshot["fallback_iv_tick_count"] = self.fallback_iv_tick_count
         return snapshot
 
-    async def update_market_state(self, raw_message: str):
+    async def update_market_state(self, raw_message: str) -> bool:
         """
         Parse one normalized message and update contract-aware market state.
 
         Schema-v1 option messages are treated as incremental legacy events.
         Schema-v2 messages carry stable identity and declare whether ``volume``
         is an incremental trade size or a cumulative counter.
+        Return True only when this message changes accepted market state.
         """
         try:
             data = json.loads(raw_message)
@@ -252,7 +253,7 @@ class StatefulGexConsumer:
             if data.get("type") == "underlying_tick":
                 if data.get("symbol") != self.target_underlying:
                     self.dropped_message_count += 1
-                    return
+                    return False
                 async with self.state_lock:
                     self.current_spot = float(data["price"])
                     if self.session_open == 0.0:
@@ -262,7 +263,7 @@ class StatefulGexConsumer:
                             self.market_time = event_time
                     self.last_message_at = time.monotonic()
                     self.message_count += 1
-                return
+                return True
 
             # 2. Update Options Traded Volume
             if data.get("type") == "options_volume_tick":
@@ -272,12 +273,12 @@ class StatefulGexConsumer:
                 )
                 if contract["symbol"] != self.target_underlying:
                     self.dropped_message_count += 1
-                    return
+                    return False
 
                 async with self.state_lock:
                     if contract["schema_version"] >= 2:
                         if not self._update_v2_contract_locked(contract, data):
-                            return
+                            return False
                         if contract.get("iv_source") == "configured_default":
                             self.fallback_iv_tick_count += 1
                         self._v2_option_count += 1
@@ -289,13 +290,14 @@ class StatefulGexConsumer:
                             self.market_time = event_time
                     self.last_message_at = time.monotonic()
                     self.message_count += 1
-                return
+                return True
 
             self.dropped_message_count += 1
 
         except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
             self.malformed_message_count += 1
             LOGGER.error("Failed parsing normalized market-data message: %s", e)
+        return False
 
     def _update_v1_projection_locked(
         self,

--- a/gex_terminal/replay_lab.py
+++ b/gex_terminal/replay_lab.py
@@ -12,7 +12,6 @@ from gex_terminal.adapters.replay import ReplayAdapter
 from gex_terminal.config import GexConfig
 from gex_terminal.consumer import StatefulGexConsumer
 from gex_terminal.engine import IntradayGexEngine
-from gex_terminal.market_data_adapter import dumps_normalized_message
 from gex_terminal.regime import build_regime_map
 from gex_terminal.replay_catalog import (
     ReplaySession,
@@ -78,8 +77,10 @@ async def analyze_replay_session(
     alerts: list[dict[str, Any]] = []
     timeline: list[dict[str, Any]] = []
     phases: set[str] = set()
+    raw_phases: set[str] = set()
     quality_cases: set[str] = set()
     timestamps: list[str] = []
+    raw_timestamps: list[str] = []
     previous_point: dict[str, Any] | None = None
 
     consumer.mark_connected()
@@ -89,13 +90,22 @@ async def analyze_replay_session(
     else:
         loaded_messages = [dict(message) for message in messages]
     for index, message in enumerate(loaded_messages, start=1):
-        _record_message_metadata(message, phases, timestamps)
+        _record_message_metadata(message, raw_phases, raw_timestamps)
         quality_case = str(message.get("quality_case", "")).strip()
         if quality_case and quality_case not in quality_cases:
             quality_cases.add(quality_case)
             alerts.append(_quality_alert(session.name, message, quality_case))
 
-        await consumer.update_market_state(dumps_normalized_message(message))
+        # The consumer owns acceptance; pre-validation here would bypass its
+        # malformed counters and stop an otherwise reviewable input audit.
+        accepted = await consumer.update_market_state(json.dumps(message))
+        if not accepted:
+            continue
+        phase = str(message.get("session_phase", "")).strip()
+        if phase:
+            phases.add(phase)
+        if consumer.market_time is not None:
+            timestamps.append(consumer.market_time.isoformat().replace("+00:00", "Z"))
         if consumer.current_spot == 0.0 or not consumer.chain_state:
             continue
 
@@ -142,7 +152,7 @@ async def analyze_replay_session(
         data=data,
         chain_state=consumer.chain_state,
         expiry_breakdown=breakdown,
-        timestamp=timestamps[-1] if timestamps else None,
+        timestamp=data["as_of"],
     )
     snapshot["replay_session"] = {
         "name": session.name,
@@ -152,6 +162,15 @@ async def analyze_replay_session(
         "phases": sorted(phases),
         "first_timestamp": timestamps[0] if timestamps else "",
         "last_timestamp": timestamps[-1] if timestamps else "",
+        "time_basis": "accepted_market_time" if timestamps else "processing_time",
+    }
+    snapshot["raw_input_audit"] = {
+        "message_count": len(loaded_messages),
+        "accepted_count": consumer.message_count,
+        "first_timestamp": raw_timestamps[0] if raw_timestamps else "",
+        "last_timestamp": raw_timestamps[-1] if raw_timestamps else "",
+        "phases": sorted(raw_phases),
+        "semantics": "input metadata only; not accepted market-state chronology",
     }
     snapshot["alerts"] = alerts
     snapshot["feed_quality"] = consumer.feed_quality_snapshot()
@@ -428,7 +447,11 @@ def _timeline_point(
     return {
         "session": session_name,
         "message_index": message_index,
-        "timestamp": _message_time(message),
+        "timestamp": data["as_of"],
+        "input_event_time": _message_time(message),
+        "time_basis": (
+            "accepted_market_time" if consumer.market_time is not None else "processing_time"
+        ),
         "phase": message.get("session_phase", ""),
         "spot": float(consumer.current_spot),
         "total_net_gex": float(data["total_net_gex"]),

--- a/tests/test_replay_chronology.py
+++ b/tests/test_replay_chronology.py
@@ -1,0 +1,96 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from gex_terminal.replay_catalog import ReplaySession
+from gex_terminal.replay_lab import analyze_replay_session
+from gex_terminal.research_journal import add_journal_entry, load_journal_entries
+from gex_terminal.session_capture import CapturedSessionWriter
+from tests.test_replay_lab import _config
+
+
+def messages():
+    option = {
+        "schema_version": 2, "type": "options_volume_tick", "provider": "synthetic",
+        "contract_id": "ES-C-5950", "symbol": "ES", "strike": 5950,
+        "option_type": "C", "volume": 10, "iv": .2, "iv_source": "provider",
+        "expiry": "2026-08-07", "expiry_timestamp": "2026-08-07T20:00:00Z",
+        "contract_multiplier": 50, "instrument_class": "futures_option",
+        "position_source": "trade_volume", "volume_semantics": "incremental",
+        "event_time": "2026-08-01T14:00:02Z", "sequence": 1,
+    }
+    return [
+        {"type": "underlying_tick", "symbol": "ES", "price": 5950,
+         "timestamp": "2026-08-01T14:00:00Z"},
+        option,
+        {"type": "underlying_tick", "symbol": "NQ", "price": 20000,
+         "timestamp": "2026-08-02T15:00:00Z", "session_phase": "rejected-late"},
+        {**option, "event_time": "2026-08-03T15:00:00Z"},  # duplicate
+        {**option, "sequence": 2, "contract_multiplier": 100,
+         "event_time": "2026-08-04T15:00:00Z"},  # identity conflict
+        {"type": "options_volume_tick", "timestamp": "2026-08-05T15:00:00Z"},
+    ]
+
+
+class ReplayChronologyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_rejected_records_remain_audit_only(self):
+        session = ReplaySession("chronology", "unused", "Chronology", "Synthetic")
+        report = await analyze_replay_session(session, _config(), messages=messages())
+        snapshot = report["snapshot"]
+        self.assertEqual(len(report["timeline"]), 1)
+        self.assertEqual(report["timeline"][0]["message_index"], 2)
+        self.assertEqual(report["timeline"][0]["input_event_time"], "2026-08-01T14:00:02Z")
+        self.assertEqual(snapshot["timestamp"], snapshot["model"]["as_of"])
+        self.assertEqual(snapshot["timestamp"], "2026-08-01T14:00:02Z")
+        self.assertEqual(report["summary"]["last_timestamp"], snapshot["timestamp"])
+        self.assertNotIn("rejected-late", report["summary"]["phases"])
+        self.assertEqual(snapshot["raw_input_audit"]["last_timestamp"], "2026-08-05T15:00:00Z")
+        self.assertEqual(snapshot["raw_input_audit"]["accepted_count"], 2)
+        self.assertIn("rejected-late", snapshot["raw_input_audit"]["phases"])
+        self.assertEqual(snapshot["feed_quality"]["dropped_count"], 1)
+        self.assertEqual(snapshot["feed_quality"]["malformed_count"], 2)
+        self.assertEqual(snapshot["feed_quality"]["duplicate_message_count"], 1)
+
+    async def test_regressed_accepted_input_does_not_regress_model_time(self):
+        rows = messages()[:2]
+        rows.append({"type": "underlying_tick", "symbol": "ES", "price": 5951,
+                     "timestamp": "2026-08-01T14:00:01Z"})
+        report = await analyze_replay_session(
+            ReplaySession("regression", "unused", "Regression", "Synthetic"),
+            _config(), messages=rows,
+        )
+        self.assertEqual(report["timeline"][-1]["timestamp"], "2026-08-01T14:00:02Z")
+        self.assertEqual(report["timeline"][-1]["input_event_time"], "2026-08-01T14:00:01Z")
+        self.assertEqual(report["snapshot"]["spot"], 5951)
+
+    async def test_untimed_legacy_input_is_labeled_processing_time(self):
+        rows = [{key: value for key, value in row.items() if key not in {"timestamp", "event_time"}}
+                for row in messages()[:2]]
+        # Legacy inputs have no exact expiry to become expired at processing time.
+        rows[1] = {"type": "options_volume_tick", "strike": 5950, "option_type": "C",
+                   "volume": 10, "iv": .2}
+        report = await analyze_replay_session(
+            ReplaySession("untimed", "unused", "Untimed", "Synthetic"),
+            _config(), messages=rows,
+        )
+        self.assertEqual(report["snapshot"]["replay_session"]["time_basis"], "processing_time")
+        self.assertEqual(report["summary"]["last_timestamp"], "")
+        self.assertEqual(report["snapshot"]["timestamp"], report["snapshot"]["model"]["as_of"])
+
+    async def test_journal_retains_accepted_time_and_separate_raw_audit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            capture = Path(directory) / "capture.jsonl"
+            writer = CapturedSessionWriter(
+                capture, source={"mode": "replay", "provider": "synthetic", "symbol": "ES"},
+                model_inputs={"contract_multiplier": 50, "days_to_expiry": .01},
+            )
+            await writer.start()
+            for row in messages()[:3]:
+                await writer.append(row)
+            await writer.finalize()
+            await add_journal_entry(_config(), Path(directory) / "journal", captured_session_path=capture)
+            entry = load_journal_entries(Path(directory) / "journal")[0]
+            self.assertEqual(entry["snapshot"]["timestamp"], "2026-08-01T14:00:02Z")
+            self.assertEqual(entry["snapshot"]["raw_input_audit"]["last_timestamp"], "2026-08-02T15:00:00Z")
+            self.assertEqual(entry["summary"]["snapshot_count"], 1)


### PR DESCRIPTION
## Outcome

Close H5 accepted-event chronology. Consumer updates explicitly return acceptance. Replay timelines and model transitions ignore rejected records while counters and raw-input audit preserve them. Snapshot time equals model as-of; input event time and processing-time-only legacy evidence stay distinct.

## Evidence

320 tests, compileall, diff hygiene and numerical model evidence passed. Focused regressions cover late off-symbol, malformed, duplicate, conflicting multiplier and regressed-time input, plus downstream journal persistence. No live evidence or predictive claim.
