### PR TITLE
fix: fail closed on configuration and report offline health truth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Required numeric settings fail closed when blank, malformed, or nonfinite.
+# Multiplier must be a positive integer; DTE, refresh, and stale limits must be
+# positive. A finite risk-free rate may be zero or negative.
 GEX_SYMBOL=ES
 GEX_SYMBOLS=ES,NQ,SPX,QQQ
 GEX_DATA_MODE=demo
@@ -10,6 +13,8 @@ GEX_REFRESH_INTERVAL_SECONDS=1.0
 GEX_STALE_AFTER_SECONDS=10.0
 # Blank uses demo_replay.jsonl from the installed gex_terminal package.
 GEX_REPLAY_PATH=
+# Replay delay is non-negative, speed is positive, and optional max gap is
+# either blank or non-negative.
 GEX_REPLAY_DELAY_SECONDS=0.05
 GEX_REPLAY_CLOCK=auto
 GEX_REPLAY_SPEED=1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ claimed.
 
 ### Fixed
 
+- Numeric configuration now fails closed across environment, direct construction
+  and CLI/UI replacement, with secret-safe errors and stale-threshold guards.
+  Offline injection/fixture reports now label replay origin and no-network
+  evidence instead of live connection health.
+
 - Replay reports now create analytical transitions only for accepted consumer
   updates, align snapshot time with model as-of, and separate raw input audit
   timestamps from accepted-state chronology. Untimed input is explicitly

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,8 +7,8 @@ This file contains planned and deferred work only. Shipped work belongs in
 belongs in [Competitive Landscape](docs/market-analysis.md).
 
 Priorities reviewed September 4, 2026 against application version `0.4.0`.
-Remaining correctness work is H2 configuration/health and H4 experiment
-identity, followed by offline preflight. The phases below remain
+Remaining P1 correctness work is H4 experiment identity, followed by offline
+preflight. The phases below remain
 conditional plans. [Application Review](docs/application-review.md) owns the
 dated health evidence and open findings.
 
@@ -21,7 +21,7 @@ an accepted work packet owns implementation status.
 
 | Order | Work | Why now | Completion evidence |
 | --- | --- | --- | --- |
-| 1 — Correctness | Close H2 and H4: configuration/health and experiment identity | A useful product must preserve the identity and validity of the result before adding delivery features | Each accepted finding has a minimal reproduction, a focused regression, and an explicit rejection or correct result through the public workflow |
+| 1 — Correctness | Close H4 experiment identity | A useful product must preserve the identity and validity of the result before adding delivery features | The accepted finding has a minimal reproduction, focused regressions, and fail-closed rejection through the public workflow |
 | 2 — Offline preflight | Add an offline `doctor` command and repair any demonstrated install/configuration failures | Users and contributors need to distinguish a broken environment from an unsupported provider | Text/JSON diagnostics work from an installed wheel outside the checkout; invalid base configuration fails; absent optional providers are explained; no connection or secret disclosure occurs |
 | 3 — Complete one research loop | Extend the existing Demo Lab with model comparison and a reproducible review receipt; add a synthetic NQ fixture where needed | Existing replay, export, journal, and experiment tools already provide most of the machinery | One authorized session yields a portable pack with source/model/quality identity, separated position models, and a reproducible result |
 | 4 — Make it usable on a fresh machine | Deliver one guided install and replay journey for the first user segment | Observed activation matters more than another command or panel | One selected distribution path passes install/upgrade checks and users complete the scoped journey without developer help |
@@ -564,8 +564,7 @@ phase uses them as a gate.
 
 ## Immediate Continuation Point
 
-Finish H2 health/configuration and H4 experiment identity as separate
-bounded repair slices with their own reproductions and regressions. Finish
+Finish H4 experiment identity with its reproductions and regressions. Finish
 this correctness sequence before extending the affected research workflows.
 
 The subsequent `GEX-PREFLIGHT-001` proposal covers the offline diagnostic command

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,10 +28,10 @@ status checklists into multiple files.
 
 An active work packet under `work-packets/` owns the status of its authorized
 change. Closed packets are historical evidence and do not make a roadmap item
-active. [GEX-HEALTH-005](work-packets/GEX-HEALTH-005.md) owns accepted-event
-chronology; independent configuration, experiment, and research-loop slices
-are isolated on their contributor branches. Merged identity and replay-lifecycle
-repairs are recorded in `GEX-HEALTH-001` and `GEX-HEALTH-003`.
+active. [GEX-HEALTH-002](work-packets/GEX-HEALTH-002.md) owns configuration and
+offline-health integration; independent experiment, preflight, and research-loop
+slices are isolated on their contributor branches. `GEX-HEALTH-001`, `003`,
+and `005` record merged identity, replay ownership, and chronology repairs.
 
 ## Start Here By Goal
 

--- a/docs/SAED_ADOPTION_PROFILE.md
+++ b/docs/SAED_ADOPTION_PROFILE.md
@@ -19,8 +19,9 @@
 **Adopted:** 2026-08-19
 
 **Status owner:** Each routed contributor packet owns its bounded slice;
-`GEX-HEALTH-005` owns chronology, and `GEX-HEALTH-001`/`003` record merged
-repairs. Closed `GEX-LIVE-001` records the `0.4.0` repository release.
+`GEX-HEALTH-002` owns configuration/health integration, and
+`GEX-HEALTH-001`/`003`/`005` record merged repairs. Closed `GEX-LIVE-001`
+records the `0.4.0` repository release.
 
 ## Purpose And Entry Boundary
 

--- a/docs/application-review.md
+++ b/docs/application-review.md
@@ -82,7 +82,16 @@ and [`yfinance_adapter.py`](../gex_terminal/adapters/yfinance_adapter.py).
 Repair acceptance also requires exports to distinguish fallback assumptions
 from the actual row multipliers, including mixed-contract cases.
 
-### H2 — P1: Health output can misrepresent offline or stale inputs
+### H2 — Resolved: Fail-closed configuration and truthful offline health
+
+Repair: every configuration construction/replacement validates numeric domain
+and finiteness; malformed environment/CLI values fail without raw-value echo.
+Consumer and feed-quality entry points defend stale thresholds. UI assumption
+changes validate before mutating the engine. Injection exports and fixture-lab
+reports explicitly carry offline/no-network origin, `REPLAY`, `DISCONNECTED`,
+and simulated/degraded health. Scripted live-lifecycle fault tests remain
+unchanged. See [GEX-HEALTH-002](work-packets/GEX-HEALTH-002.md). The following
+describes the original defect.
 
 The normal offline command
 `inject-provider bundled:yfinance-etf-options --export spy.json` emits

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,8 +217,12 @@ Generated output stays local by default under ignored folders such as
 
 Provider readiness is not runtime connection status. The readiness vocabulary
 is `offline-certified`, `delayed`, `scaffold`, `live-uncertified`, and
-`live-certified`. Runtime state remains `SIM`, `LIVE`, `STALE`, or
-`DISCONNECTED`; a live connection never promotes readiness by itself.
+`live-certified`. Runtime state includes `SIM`, `REPLAY`, `CONNECTED`, `LIVE`,
+`STALE`, and `DISCONNECTED`; a live connection never promotes readiness by itself.
+Provider-shaped injection is `REPLAY` with a disconnected transport and explicit
+offline/no-network origin. Scripted fault tests may model live transitions, but
+remain marked as simulations. Frozen `GexConfig` validates numeric values at
+construction/replacement; UI updates validate before publishing state changes.
 
 ## State Ownership
 

--- a/docs/examples/provider_fixture_lab.md
+++ b/docs/examples/provider_fixture_lab.md
@@ -1,8 +1,10 @@
 # Offline Provider Fixture Workbench
 
-- Generated: `2026-08-05T00:30:28`
+- Generated: `2026-09-04T13:40:02`
 - Cases run: `5`
 - Passed: `5`
+- Healthy live: `0`
+- Simulated: `3`
 - Degraded: `2`
 - Failed: `0`
 - Days to expiry: `0.25`
@@ -14,13 +16,13 @@ It is not a portfolio root obtained by repricing across hypothetical spot.
 
 ## Provider Scorecard
 
-| Case | Provider | Format | Symbol | Health | Messages | Frames | Parse Err | Dropped | Gamma Wall | Zero Gamma |
-| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| Tradovate Live Frames | tradovate | tradovate | ES | degraded | 6 | 3 | 1 | 1 | 5,950.0 | 5,909.6 |
-| Tradovate Metadata Join | tradovate | tradovate | ES | healthy | 3 | 1 | 0 | 0 | 5,950.0 | 5,907.4 |
-| Databento GLBX Fixture | databento | databento | ES | degraded | 4 | 4 | 0 | 0 | 5,950.0 | 5,906.0 |
-| yfinance ETF Options | yfinance | yfinance | SPY | healthy | 5 | 1 | 0 | 0 | 515.0 | 505.5 |
-| Cboe Option Quotes CSV | cboe | cboe-option-quotes | SPY | healthy | 8 | 4 | 0 | 0 | 515.0 | 505.5 |
+| Case | Provider | Format | Symbol | Mode | Network | Health | Messages | Frames | Parse Err | Dropped | Gamma Wall | Zero Gamma |
+| --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Tradovate Live Frames | tradovate | tradovate | ES | REPLAY | no | degraded | 6 | 3 | 1 | 1 | 5,950.0 | 5,909.6 |
+| Tradovate Metadata Join | tradovate | tradovate | ES | REPLAY | no | simulated | 3 | 1 | 0 | 0 | 5,950.0 | 5,907.4 |
+| Databento GLBX Fixture | databento | databento | ES | REPLAY | no | degraded | 4 | 4 | 0 | 0 | 5,950.0 | 5,906.0 |
+| yfinance ETF Options | yfinance | yfinance | SPY | REPLAY | no | simulated | 5 | 1 | 0 | 0 | 515.0 | 505.5 |
+| Cboe Option Quotes CSV | cboe | cboe-option-quotes | SPY | REPLAY | no | simulated | 8 | 4 | 0 | 0 | 515.0 | 505.5 |
 
 ## Case Notes
 
@@ -29,45 +31,50 @@ It is not a portfolio root obtained by repricing across hypothetical spot.
 - Fixture: `gex_terminal/data/provider_fixtures/tradovate_live_sample.jsonl`
 - Description: Sanitized WebSocket-style quote frames with one intentionally malformed quote for feed-health testing.
 - Command: `gex-terminal inject-provider bundled:tradovate-live-sample`
-- Result: `degraded` health, `6` normalized messages, `3` provider frames.
+- Source: `offline_provider_fixture`; network used `no`; runtime `REPLAY` / `DISCONNECTED`.
+- Result: `computed` mapping, `degraded` health, `6` normalized messages, `3` provider frames.
 - Levels: gamma wall `5,950.0`, zero gamma `5,909.6`, net GEX `+34.45M`.
-- Notes: `provider frame parse errors recorded; malformed payloads recorded; unsupported or off-symbol payloads dropped`
+- Notes: `simulated local feed; provider frame parse errors recorded; malformed payloads recorded; unsupported or off-symbol payloads dropped`
 
 ### Tradovate Metadata Join
 
 - Fixture: `gex_terminal/data/provider_fixtures/tradovate_md_quotes.json`
 - Description: Quote payload joined to sanitized contract-discovery metadata.
 - Command: `gex-terminal inject-provider bundled:tradovate-md-quotes`
-- Result: `healthy` health, `3` normalized messages, `1` provider frames.
+- Source: `offline_provider_fixture`; network used `no`; runtime `REPLAY` / `DISCONNECTED`.
+- Result: `computed` mapping, `simulated` health, `3` normalized messages, `1` provider frames.
 - Levels: gamma wall `5,950.0`, zero gamma `5,907.4`, net GEX `+28.23M`.
-- Notes: `feed checks clean`
+- Notes: `simulated local feed`
 
 ### Databento GLBX Fixture
 
 - Fixture: `gex_terminal/data/provider_fixtures/databento_trade_records.json`
 - Description: Synthetic GLBX.MDP3 definitions, option trades, and underlying mbp-1 quote sample.
 - Command: `gex-terminal inject-provider bundled:databento-glbx`
-- Result: `degraded` health, `4` normalized messages, `4` provider frames.
+- Source: `offline_provider_fixture`; network used `no`; runtime `REPLAY` / `DISCONNECTED`.
+- Result: `computed` mapping, `degraded` health, `4` normalized messages, `4` provider frames.
 - Levels: gamma wall `5,950.0`, zero gamma `5,906.0`, net GEX `+10.91M`.
-- Notes: `3 option tick(s) used labeled fallback IV`
+- Notes: `simulated local feed; 3 option tick(s) used labeled fallback IV`
 
 ### yfinance ETF Options
 
 - Fixture: `gex_terminal/data/provider_fixtures/yfinance_option_chain_records.json`
 - Description: Delayed equity/ETF option-chain sample for SPY-style research.
 - Command: `gex-terminal inject-provider bundled:yfinance-etf-options`
-- Result: `healthy` health, `5` normalized messages, `1` provider frames.
+- Source: `offline_provider_fixture`; network used `no`; runtime `REPLAY` / `DISCONNECTED`.
+- Result: `computed` mapping, `simulated` health, `5` normalized messages, `1` provider frames.
 - Levels: gamma wall `515.0`, zero gamma `505.5`, net GEX `+2.50M`.
-- Notes: `feed checks clean`
+- Notes: `simulated local feed`
 
 ### Cboe Option Quotes CSV
 
 - Fixture: `gex_terminal/data/provider_fixtures/cboe_option_quotes_sample.csv`
 - Description: Cboe-style option quote CSV sample using common column names.
 - Command: `gex-terminal inject-provider bundled:cboe-option-quotes-csv`
-- Result: `healthy` health, `8` normalized messages, `4` provider frames.
+- Source: `offline_provider_fixture`; network used `no`; runtime `REPLAY` / `DISCONNECTED`.
+- Result: `computed` mapping, `simulated` health, `8` normalized messages, `4` provider frames.
 - Levels: gamma wall `515.0`, zero gamma `505.5`, net GEX `+1.24M`.
-- Notes: `feed checks clean`
+- Notes: `simulated local feed`
 
 ## Contributor Uses
 

--- a/docs/provider-injection.md
+++ b/docs/provider-injection.md
@@ -8,6 +8,13 @@ This does not prove live entitlements, current provider field drift, or real
 network reconnect behavior. It does prove that captured or documented samples
 can become inspectable GEX state.
 
+Injection is represented as completed local replay: returned artifacts record
+`source_kind=offline_provider_fixture`, `network_used=false`, runtime status
+`REPLAY`, and connection state `DISCONNECTED`. A clean fixture has `simulated`
+health; parser, mapping, or model-quality counters can still make it `degraded`.
+The named provider identifies the mapping under test, not an observed live
+connection or provider-readiness result.
+
 ## Provider Fixture Workbench
 
 Run every bundled provider-shaped fixture through the offline workbench:
@@ -23,6 +30,9 @@ metadata join, Databento GLBX-style fixtures, a yfinance ETF option-chain sample
 and a Cboe-style option quote CSV. Use it before and after adapter changes to
 produce one shareable pass/fail scorecard with health counters, computed gamma
 wall, strike-profile flip/compatibility level, and saved snapshot baselines.
+`Passed` means the fixture produced a computable mapping and snapshot. The
+scorecard counts `simulated`, `degraded`, and any genuinely `healthy` result
+separately, so a mapping pass is never presented as live-provider health.
 
 The checked-in example output is available at
 [docs/examples/provider_fixture_lab.md](examples/provider_fixture_lab.md).
@@ -108,10 +118,14 @@ The command prints a compact operator summary with:
 - dropped payload count
 - subscription status
 - subscribed symbol count
-- health state
+- offline source kind and whether a network was used
+- runtime mode, completion connection state, and health state
 
 Use `--export .json`, `--export .csv`, or `--export .md` to save the full
-snapshot, including `provider_injection` metadata and `feed_quality` counters.
+snapshot. `provider_injection` preserves provider/format mapping provenance,
+fixture paths, `source_kind`, `network_used`, `mapping_status`, and normalized
+message count. `feed_quality` separately preserves runtime status/mode,
+connection state, health, subscription evidence, and quality counters.
 
 The `bundled:NAME` selector resolves resources inside either the source package
 or installed wheel. Pass a filesystem path, `--metadata`, and

--- a/docs/work-packets/GEX-HEALTH-002.md
+++ b/docs/work-packets/GEX-HEALTH-002.md
@@ -167,6 +167,12 @@ None.
 
 ## Evidence
 
+Integration at `main@813bb24` preserved H1 multiplier identity, H3 writer
+ownership, and H5 chronology. An additional regression validates UI assumption
+changes before publishing engine mutations. All 333 integrated tests,
+compilation, diff hygiene, and the 7/7 provider-fault gate passed. Hosted checks
+and clean-main verification remain pending at this integration commit.
+
 Repository evidence on the isolated contributor branch:
 
 - Focused configuration, CLI, feed-quality, injection, fixture-lab,

--- a/docs/work-packets/GEX-HEALTH-002.md
+++ b/docs/work-packets/GEX-HEALTH-002.md
@@ -1,0 +1,192 @@
+# GEX-HEALTH-002 — Configuration And Offline Health Truth
+
+```yaml
+method: saed
+method_version: "1.3"
+profile: gex-terminal-team-v1
+adoption_context: team
+change_rigor: L3
+status: "Ready for integration — branch evidence passed"
+packet_owner: project maintainer
+spec_steward: implementation agent
+architecture_authority: project maintainer
+evidence_reviewer: pull-request reviewer and hosted CI
+baseline: main@4c79f1f
+branch: codex/gex-health-002-config-truth
+created: 2026-09-04
+external_outcome: "Not applicable — offline correctness only"
+```
+
+## Authorization And Routing
+
+The maintainer authorized the repository-owned H2 repair identified in the
+September 4 application review: validate configuration before runtime or
+export, produce actionable errors without echoing supplied values, and make
+offline provider injection visibly simulated. Work is isolated on the named
+contributor branch and will be integrated through a later reviewed pull
+request. No credentialed provider call, live observation, readiness promotion,
+release tag, or publication is authorized by this packet.
+
+This is routed as `L3` because it changes the enforced configuration boundary
+and the meaning of durable provider-health evidence. The implementation keeps
+mutable market state in `StatefulGexConsumer`, preserves provider mapping
+paths, and leaves the deliberately scripted live lifecycle harness unchanged.
+
+## Problem And Intended Outcome
+
+Malformed numeric environment values currently fall back to plausible
+defaults, while nonfinite values can reach stale detection. A nonfinite stale
+threshold can cause old data to appear healthy. Direct `GexConfig`
+construction and command-line overrides do not share one complete invariant
+check.
+
+Separately, local provider-shaped fixtures are injected through a consumer
+labeled `LIVE` and `CONNECTED`, so a no-network artifact can report healthy
+live state. After this change, every runtime/export configuration fails closed
+on invalid numeric assumptions, public errors identify the field and expected
+constraint without repeating its raw value, and provider fixture artifacts
+state their offline origin and simulated runtime unambiguously.
+
+## Scope
+
+- One `GexConfig` validation boundary for environment loading, direct
+  construction, and `dataclasses.replace` command/UI overrides.
+- Strict required and optional numeric parsing with finite/domain checks.
+- Secret-safe, actionable command-line configuration failures.
+- Defensive stale-threshold validation at consumer and feed-quality ingress.
+- Explicit offline origin, no-network evidence, and replay/simulated runtime
+  semantics for provider fixture injection and its workbench exports.
+- Focused unit, CLI, fixture, release-contract, and scripted-fault regression
+  evidence plus canonical provider-injection/configuration documentation.
+
+## Non-Goals
+
+- Symbol/multiplier identity redesign, instrument-profile policy, or changes to
+  model calculations.
+- Replay task ownership, experiment identity, replay chronology, or terminal
+  layout repairs from other health findings.
+- Credentialed provider testing, provider readiness changes, retained market
+  data, predictive claims, or profitability claims.
+- Requiring a replay path to exist during intermediate configuration assembly;
+  adapters continue to validate paths at execution time.
+- Inventing an empirical bound for a finite risk-free rate.
+
+## Invariants
+
+This packet adopts `INV-01` through `INV-08` from
+`docs/SAED_ADOPTION_PROFILE.md` and adds:
+
+- `INV-21` — Invalid required numeric configuration never becomes a default;
+  only absence selects a default, and only an absent or blank optional value
+  becomes `None`.
+- `INV-22` — Runtime timing and expiry values are finite and inside their
+  declared positive or non-negative domains before work begins.
+- `INV-23` — Public configuration errors identify only the field and safe
+  constraint, never the supplied environment or command-line value.
+- `INV-24` — Offline provider fixtures never emit `LIVE`, claim a network
+  connection, or count simulated execution as observed provider health.
+- `INV-25` — Scripted live lifecycle cases remain explicitly synthetic and
+  cannot set `live_transport_certified=true`.
+
+## Requirements And Acceptance
+
+| ID | Requirement / Acceptance Criterion | Evidence | Status |
+| --- | --- | --- | --- |
+| `REQ-01` | `GexConfig` rejects nonfinite and out-of-domain multiplier, rate, expiry, refresh, stale, replay-delay, replay-speed, and replay-gap values on direct construction. | Table-driven configuration tests | Verified |
+| `AC-01` | Multiplier is a positive integer; rate is finite; expiry, refresh, stale, and replay speed are finite and positive; replay delay and optional max gap are finite and non-negative. | Boundary tests | Verified |
+| `REQ-02` | Environment parsing distinguishes absent defaults and optional blanks from malformed values. | Environment tests | Verified |
+| `REQ-03` | CLI overrides use the same invariant boundary and fail with a concise nonzero result, no traceback, and no raw supplied sentinel. | Adversarial subprocess tests | Verified |
+| `AC-02` | An invalid stale threshold cannot yield a healthy feed-quality result through supported config, consumer, or direct feed-quality entry points. | Consumer/feed-quality tests | Verified |
+| `REQ-04` | Provider injection records an offline fixture source, `network_used=false`, and replay/simulated or degraded health rather than live/connected health. | Public injection export and summary tests | Verified |
+| `AC-03` | Fixture-lab summaries and scorecards distinguish mapping pass, simulated runtime, and degraded parser/model evidence. | Workbench JSON/CSV/Markdown tests | Verified |
+| `AC-04` | Provider fault certification still passes every scripted case and retains `live_transport_certified=false`. | Offline fault gate | Verified |
+| `AC-05` | Focused tests, full discovery, source compilation, patch hygiene, and installed-wheel offline smoke pass. | Branch evidence | Verified |
+
+## Architecture Delta
+
+Configuration validation becomes an ingress contract rather than a downstream
+side effect:
+
+```text
+environment / CLI / direct constructor
+              |
+              v
+       validated GexConfig
+              |
+              +--> consumer/feed-quality guards
+              |
+local provider fixture --> adapter mapping --> consumer/engine --> artifact
+       source=offline fixture                 status=REPLAY, network=false
+```
+
+The provider identifier continues to describe the parser/mapping under test;
+it does not describe an observed connection or provider readiness. Scripted
+fault certification retains its intentionally live-shaped state transitions
+under an explicit no-network evidence ceiling.
+
+## Bounded Slices
+
+| Slice | Deliverable | Evidence | Fallback / Stop Point |
+| --- | --- | --- | --- |
+| `S1` Route | Accepted packet, baseline, branch, invariants | Structural review | Stop before runtime edits if scope changes |
+| `S2` Config | Strict parsers and direct-construction validation | Config and CLI tests | Keep prior defaults only for absent values |
+| `S3` Health | Consumer/feed-quality ingress guards | Stale/nonfinite tests | Fail closed rather than guess health |
+| `S4` Fixture truth | Offline metadata, runtime semantics, summaries | Injection/workbench/fault tests | Preserve parser counters and fault harness |
+| `S5` Reconcile | Canonical guide and generated example | Link/content review | Do not duplicate roadmap or architecture |
+| `S6` Verify | Focused/full/package checks and contributor commit | Exact branch evidence | Do not integrate on failed critical gate |
+
+## Risks And Controls
+
+| ID | Risk | Control / Recovery |
+| --- | --- | --- |
+| `RISK-01` | New checks reject an intentional boundary such as zero replay delay. | Encode positive versus non-negative fields explicitly and test boundaries. |
+| `RISK-02` | A validation message leaks an accidental secret used as an invalid value. | Construct messages from fixed field names and constraints; adversarially assert the sentinel is absent. |
+| `RISK-03` | Offline parser evidence is mistaken for a provider connection. | Emit source kind, network use, replay status, connection state, and simulated health together. |
+| `RISK-04` | Relabeling fixture execution weakens scripted lifecycle coverage. | Do not change the provider fault lifecycle case; run its complete gate. |
+| `RISK-05` | Validation overlaps the instrument-identity slice. | Do not infer multiplier from symbol or change H1 identity behavior; integrate branches serially. |
+
+## Verification And Integration Plan
+
+1. Run focused configuration, CLI, consumer, feed-quality, injection, fixture-
+   lab, release-contract, safety, and provider-fault tests.
+2. Run full unit discovery, source compilation, `git diff --check`, and local
+   documentation-link inspection.
+3. Build source and wheel distributions, install the wheel into a temporary
+   environment outside the checkout, and run only offline injection and invalid-
+   configuration smoke commands.
+4. Commit explicit packet, implementation, test, and canonical documentation
+   paths on the contributor branch. Do not push, merge, tag, or make a live call
+   in this slice.
+
+Rollback is a Git revert of the contributor commit. No user state, licensed
+market data, credentials, or external system is mutated.
+
+## Amendments
+
+None.
+
+## Evidence
+
+Repository evidence on the isolated contributor branch:
+
+- Focused configuration, CLI, feed-quality, injection, fixture-lab,
+  release-contract, and safety coverage passed all 50 tests, including
+  secret-shaped invalid environment and command-line values that were absent
+  from stderr and produced no traceback.
+- Full unit discovery passed all 309 tests. Source compilation and
+  `git diff --check` also passed.
+- The regenerated fixture-lab example passed 5/5 mappings while reporting zero
+  healthy-live cases, three simulated cases, and two degraded cases. Every row
+  reports replay mode and no network use; exported injection evidence reports
+  an offline fixture source and a disconnected consumer.
+- The unchanged scripted provider-fault suite retained its deliberately
+  synthetic lifecycle coverage and `live_transport_certified=false` ceiling.
+- Source and wheel distributions built successfully and both passed Twine
+  validation. The wheel was installed outside the checkout; its offline
+  provider-injection command emitted replay/disconnected/simulated truth, and
+  its adversarial invalid-environment command failed concisely without the raw
+  sentinel or a traceback.
+
+No credentialed provider call or network-backed market-data observation was
+performed. This evidence establishes repository behavior only; it cannot
+certify live transport, provider capacity, or predictive validity.

--- a/docs/work-packets/GEX-HEALTH-005.md
+++ b/docs/work-packets/GEX-HEALTH-005.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: ready for contributor review
+status: closed
 packet_owner: project maintainer
 branch: codex/gex-health-005-accepted-chronology
 created: 2026-09-04
@@ -40,4 +40,6 @@ Revert the merge for code recovery. Existing artifacts are not rewritten.
   separate late rejected input from model time and persist that boundary through
   the journal workflow.
 - All 320 tests, compileall, diff hygiene and numerical model evidence passed.
-- Hosted checks and clean merged-main verification remain pending.
+- [PR #22](https://github.com/zrack/gex-terminal/pull/22) passed all four hosted
+  checks and merged as `813bb24`. Clean merged main passed all 320 tests and
+  source compilation with no working-tree changes.

--- a/gex_terminal/cli.py
+++ b/gex_terminal/cli.py
@@ -22,7 +22,7 @@ from gex_terminal.capture_governance import (
     capture_policy_identity,
     load_capture_policy,
 )
-from gex_terminal.config import GexConfig
+from gex_terminal.config import ConfigValidationError, GexConfig
 from gex_terminal.consumer import StatefulGexConsumer
 from gex_terminal.databento_certification import (
     build_databento_certification_report,
@@ -1152,6 +1152,22 @@ async def compute_snapshot(
     return snapshot, consumer, data
 
 
+def _safe_float_argument(value: str) -> float:
+    """Parse a CLI number without echoing a rejected raw value."""
+    try:
+        return float(value)
+    except (OverflowError, TypeError, ValueError):
+        raise argparse.ArgumentTypeError("must be numeric") from None
+
+
+def _safe_integer_argument(value: str) -> int:
+    """Parse a CLI integer without echoing a rejected raw value."""
+    try:
+        return int(value)
+    except (OverflowError, TypeError, ValueError):
+        raise argparse.ArgumentTypeError("must be an integer") from None
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Intraday GEX imbalance terminal",
@@ -1233,7 +1249,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--multiplier",
-        type=int,
+        type=_safe_integer_argument,
         help="Contract multiplier. Overrides GEX_CONTRACT_MULTIPLIER.",
     )
     parser.add_argument(
@@ -1242,7 +1258,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--refresh",
-        type=float,
+        type=_safe_float_argument,
         help="UI refresh interval in seconds. Overrides GEX_REFRESH_INTERVAL_SECONDS.",
     )
     parser.add_argument(
@@ -1283,7 +1299,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--replay-delay",
-        type=float,
+        type=_safe_float_argument,
         help="Delay between replay messages in seconds. Overrides GEX_REPLAY_DELAY_SECONDS.",
     )
     parser.add_argument(
@@ -1293,12 +1309,12 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--replay-speed",
-        type=float,
+        type=_safe_float_argument,
         help="Event-time replay speed multiplier. Overrides GEX_REPLAY_SPEED.",
     )
     parser.add_argument(
         "--replay-max-gap",
-        type=float,
+        type=_safe_float_argument,
         help="Optional maximum source-time gap before replay-speed scaling.",
     )
     parser.add_argument(
@@ -1392,19 +1408,19 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--certification-duration",
-        type=float,
+        type=_safe_float_argument,
         default=10.0,
         help="Seconds to observe a provider certification stream. Default: 10.",
     )
     parser.add_argument(
         "--max-underlying-age",
-        type=float,
+        type=_safe_float_argument,
         default=2.0,
         help="Maximum seconds between futures midpoint and option trade for IV inversion. Default: 2.",
     )
     parser.add_argument(
         "--max-option-contracts",
-        type=int,
+        type=_safe_integer_argument,
         default=12,
         help="Maximum option subscriptions during Tradovate certification. Default: 12.",
     )
@@ -1414,25 +1430,25 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--performance-contracts",
-        type=int,
+        type=_safe_integer_argument,
         default=500,
         help="Generated option contracts for performance-certify. Default: 500.",
     )
     parser.add_argument(
         "--minimum-ingest-rps",
-        type=float,
+        type=_safe_float_argument,
         default=50.0,
         help="Minimum generated ingest records/second. Default: 50.",
     )
     parser.add_argument(
         "--maximum-snapshot-ms",
-        type=float,
+        type=_safe_float_argument,
         default=1000.0,
         help="Maximum generated snapshot milliseconds. Default: 1000.",
     )
     parser.add_argument(
         "--maximum-peak-mb",
-        type=float,
+        type=_safe_float_argument,
         default=256.0,
         help="Maximum generated-chain peak memory in MiB. Default: 256.",
     )
@@ -1443,13 +1459,13 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--screenshot-width",
-        type=int,
+        type=_safe_integer_argument,
         default=180,
         help="Terminal columns for --screenshot export. Default: 180.",
     )
     parser.add_argument(
         "--screenshot-height",
-        type=int,
+        type=_safe_integer_argument,
         default=54,
         help="Terminal rows for --screenshot export. Default: 54.",
     )
@@ -1524,15 +1540,15 @@ def validate_data_mode(data_mode: str) -> None:
     supported_modes = {"demo", "replay", "live"}
     if data_mode not in supported_modes:
         raise SystemExit(
-            f"Unsupported GEX_DATA_MODE '{data_mode}'. Expected one of: demo, replay, live"
+            "Unsupported GEX_DATA_MODE. Expected one of: demo, replay, live"
         )
 
 
 def validate_provider(config: GexConfig) -> None:
     if effective_provider(config) not in available_provider_names():
         raise SystemExit(
-            f"Unsupported GEX_DATA_PROVIDER '{config.data_provider}'. "
-            f"Expected one of: {', '.join(available_provider_names())}"
+            "Unsupported GEX_DATA_PROVIDER. Expected one of: "
+            f"{', '.join(available_provider_names())}"
         )
 
 
@@ -1619,7 +1635,10 @@ def _session_store_source_name(config: GexConfig, args: argparse.Namespace) -> s
 
 
 def main_sync() -> None:
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except ConfigValidationError as exc:
+        raise SystemExit(f"Configuration error: {exc}") from None
 
 
 if __name__ == "__main__":

--- a/gex_terminal/config.py
+++ b/gex_terminal/config.py
@@ -1,5 +1,7 @@
+import math
 import os
 from dataclasses import dataclass
+from numbers import Integral, Real
 from pathlib import Path
 
 from gex_terminal.package_data import replay_data_path
@@ -8,6 +10,11 @@ try:
     from dotenv import load_dotenv as _python_dotenv_load
 except ModuleNotFoundError:
     _python_dotenv_load = None
+
+
+class ConfigValidationError(ValueError):
+    """A redaction-safe configuration parsing or domain failure."""
+
 
 @dataclass(frozen=True)
 class GexConfig:
@@ -28,6 +35,61 @@ class GexConfig:
     replay_speed: float = 1.0
     replay_max_gap_seconds: float | None = None
     strict_event_time: bool = False
+
+    def __post_init__(self) -> None:
+        """Enforce the runtime numeric contract for every construction path."""
+        object.__setattr__(
+            self,
+            "contract_multiplier",
+            _positive_integer(self.contract_multiplier, "contract_multiplier"),
+        )
+        object.__setattr__(
+            self,
+            "risk_free_rate",
+            _finite_number(self.risk_free_rate, "risk_free_rate"),
+        )
+        object.__setattr__(
+            self,
+            "days_to_expiry",
+            _positive_number(self.days_to_expiry, "days_to_expiry"),
+        )
+        object.__setattr__(
+            self,
+            "refresh_interval_seconds",
+            _positive_number(
+                self.refresh_interval_seconds,
+                "refresh_interval_seconds",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "stale_after_seconds",
+            _positive_number(self.stale_after_seconds, "stale_after_seconds"),
+        )
+        object.__setattr__(
+            self,
+            "replay_delay_seconds",
+            _non_negative_number(
+                self.replay_delay_seconds,
+                "replay_delay_seconds",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "replay_speed",
+            _positive_number(self.replay_speed, "replay_speed"),
+        )
+        if self.replay_max_gap_seconds is not None:
+            object.__setattr__(
+                self,
+                "replay_max_gap_seconds",
+                _non_negative_number(
+                    self.replay_max_gap_seconds,
+                    "replay_max_gap_seconds",
+                ),
+            )
+        if not isinstance(self.strict_event_time, bool):
+            raise ConfigValidationError("strict_event_time must be true or false")
 
     @classmethod
     def from_env(cls) -> "GexConfig":
@@ -62,17 +124,26 @@ def _env_str(name: str, default: str) -> str:
 
 
 def _env_int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, str(default)))
-    except ValueError:
+    value = os.getenv(name)
+    if value is None:
         return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise ConfigValidationError(f"{name} must be an integer") from None
 
 
 def _env_float(name: str, default: float) -> float:
-    try:
-        return float(os.getenv(name, str(default)))
-    except ValueError:
+    value = os.getenv(name)
+    if value is None:
         return default
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        raise ConfigValidationError(f"{name} must be numeric") from None
+    if not math.isfinite(number):
+        raise ConfigValidationError(f"{name} must be finite")
+    return number
 
 
 def _env_optional_float(name: str) -> float | None:
@@ -80,9 +151,12 @@ def _env_optional_float(name: str) -> float | None:
     if value is None or not value.strip():
         return None
     try:
-        return float(value)
-    except ValueError:
-        return None
+        number = float(value)
+    except (TypeError, ValueError):
+        raise ConfigValidationError(f"{name} must be numeric or blank") from None
+    if not math.isfinite(number):
+        raise ConfigValidationError(f"{name} must be finite or blank")
+    return number
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -94,7 +168,50 @@ def _env_bool(name: str, default: bool) -> bool:
         return True
     if normalized in {"0", "false", "no", "off"}:
         return False
-    return default
+    raise ConfigValidationError(
+        f"{name} must be true or false (accepted: 1/0, true/false, yes/no, on/off)"
+    )
+
+
+def _finite_number(value: Real, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ConfigValidationError(f"{name} must be numeric")
+    try:
+        number = float(value)
+    except OverflowError:
+        raise ConfigValidationError(f"{name} must be finite") from None
+    if not math.isfinite(number):
+        raise ConfigValidationError(f"{name} must be finite")
+    return number
+
+
+def _positive_number(value: Real, name: str) -> float:
+    number = _finite_number(value, name)
+    if number <= 0:
+        raise ConfigValidationError(f"{name} must be greater than 0")
+    return number
+
+
+def _non_negative_number(value: Real, name: str) -> float:
+    number = _finite_number(value, name)
+    if number < 0:
+        raise ConfigValidationError(f"{name} must be greater than or equal to 0")
+    return number
+
+
+def _positive_integer(value: Integral, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ConfigValidationError(f"{name} must be an integer")
+    number = int(value)
+    try:
+        finite = math.isfinite(float(number))
+    except OverflowError:
+        finite = False
+    if not finite:
+        raise ConfigValidationError(f"{name} must be finite")
+    if number <= 0:
+        raise ConfigValidationError(f"{name} must be greater than 0")
+    return number
 
 
 def _env_symbols(name: str, default: tuple[str, ...], target_symbol: str) -> tuple[str, ...]:

--- a/gex_terminal/consumer.py
+++ b/gex_terminal/consumer.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import math
 import time
 import numpy as np
 from datetime import datetime, timezone
@@ -20,6 +21,24 @@ from gex_terminal.market_data_adapter import validate_normalized_message
 
 LOGGER = logging.getLogger(__name__)
 
+
+def _finite_runtime_number(value: object, name: str) -> float:
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        raise ValueError(f"{name} must be numeric") from None
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite")
+    return number
+
+
+def _positive_runtime_number(value: object, name: str) -> float:
+    number = _finite_runtime_number(value, name)
+    if number <= 0:
+        raise ValueError(f"{name} must be greater than 0")
+    return number
+
+
 class StatefulGexConsumer:
     def __init__(
         self,
@@ -32,9 +51,15 @@ class StatefulGexConsumer:
     ):
         self.engine = engine
         self.target_underlying = target_underlying
-        self.risk_free_rate = risk_free_rate
+        self.risk_free_rate = _finite_runtime_number(
+            risk_free_rate,
+            "risk_free_rate",
+        )
         self.data_mode = data_mode.upper()
-        self.stale_after_seconds = stale_after_seconds
+        self.stale_after_seconds = _positive_runtime_number(
+            stale_after_seconds,
+            "stale_after_seconds",
+        )
         self.expiry_filter = expiry_filter
         
         # Compatibility summaries consumed by the existing TUI/export surface.
@@ -98,14 +123,25 @@ class StatefulGexConsumer:
     ) -> None:
         """Clear market state before loading a fresh offline or provider session."""
         next_mode = (data_mode or self.data_mode).upper()
+        next_risk_free_rate = (
+            self.risk_free_rate
+            if risk_free_rate is None
+            else _finite_runtime_number(risk_free_rate, "risk_free_rate")
+        )
+        next_stale_after_seconds = (
+            self.stale_after_seconds
+            if stale_after_seconds is None
+            else _positive_runtime_number(
+                stale_after_seconds,
+                "stale_after_seconds",
+            )
+        )
         async with self.state_lock:
             self.data_mode = next_mode
             if target_underlying:
                 self.target_underlying = target_underlying
-            if risk_free_rate is not None:
-                self.risk_free_rate = float(risk_free_rate)
-            if stale_after_seconds is not None:
-                self.stale_after_seconds = float(stale_after_seconds)
+            self.risk_free_rate = next_risk_free_rate
+            self.stale_after_seconds = next_stale_after_seconds
             self.chain_state.clear()
             self.expiry_state.clear()
             self._legacy_chain_state.clear()

--- a/gex_terminal/feed_quality.py
+++ b/gex_terminal/feed_quality.py
@@ -1,5 +1,6 @@
 """Provider feed-quality summaries for the terminal and tests."""
 
+import math
 from dataclasses import asdict, dataclass
 
 
@@ -55,9 +56,16 @@ def build_feed_quality_snapshot(
     p95_latency_ms: float = 0.0,
 ) -> FeedQualitySnapshot:
     """Build a consistent feed-health snapshot from runtime counters."""
+    try:
+        stale_threshold = float(stale_after_seconds)
+    except (OverflowError, TypeError, ValueError):
+        raise ValueError("stale_after_seconds must be numeric") from None
+    if not math.isfinite(stale_threshold) or stale_threshold <= 0:
+        raise ValueError("stale_after_seconds must be finite and greater than 0")
+
     stale = status == "STALE" or (
         last_message_age_seconds is not None
-        and last_message_age_seconds > stale_after_seconds
+        and last_message_age_seconds > stale_threshold
         and data_mode not in {"DEMO"}
     )
     notes: list[str] = []
@@ -112,7 +120,7 @@ def build_feed_quality_snapshot(
         subscription_status=subscription_status,
         last_message_age_seconds=last_message_age_seconds,
         last_snapshot_age_seconds=last_snapshot_age_seconds,
-        stale_after_seconds=float(stale_after_seconds),
+        stale_after_seconds=stale_threshold,
         stale=bool(stale),
         latency_ms=float(latency_ms),
         p95_latency_ms=float(p95_latency_ms),

--- a/gex_terminal/provider_fixture_lab.py
+++ b/gex_terminal/provider_fixture_lab.py
@@ -138,7 +138,7 @@ async def analyze_provider_fixture_case(
         config,
         symbol=case.symbol,
         symbols=_symbols_with_target(config.symbols, case.symbol),
-        data_mode="live",
+        data_mode="replay",
         data_provider=case.provider,
         replay_delay_seconds=0.0,
     )
@@ -197,9 +197,14 @@ def summarize_provider_fixture_snapshot(
         "symbol": snapshot.get("symbol", case.symbol),
         "fixture": injection.get("fixture") or _portable_path(case.fixture_path),
         "fixture_format": injection.get("fixture_format") or case.fixture_format,
+        "source_kind": injection.get("source_kind", "offline_provider_fixture"),
+        "network_used": bool(injection.get("network_used", False)),
+        "mapping_status": injection.get("mapping_status", "unknown"),
         "metadata": injection.get("metadata"),
         "underlying_fixture": injection.get("underlying_fixture"),
         "status": quality.get("status", "unknown"),
+        "data_mode": quality.get("data_mode", "unknown"),
+        "connection_state": quality.get("connection_state", "unknown"),
         "health": quality.get("health", "unknown"),
         "notes": list(quality.get("notes") or ()),
         "spot": float(snapshot.get("spot", 0.0)),
@@ -227,6 +232,8 @@ def build_provider_fixture_scorecard(
     rows = [result["summary"] for result in results]
     passed = sum(1 for row in rows if row["ok"])
     failed = len(rows) - passed
+    healthy = sum(1 for row in rows if row["ok"] and row["health"] == "healthy")
+    simulated = sum(1 for row in rows if row["ok"] and row["health"] == "simulated")
     degraded = sum(
         1
         for row in rows
@@ -236,7 +243,8 @@ def build_provider_fixture_scorecard(
         "total": len(rows),
         "passed": passed,
         "failed": failed,
-        "healthy": passed - degraded,
+        "healthy": healthy,
+        "simulated": simulated,
         "degraded": degraded,
         "normalized_messages": sum(int(row.get("normalized_messages", 0)) for row in rows),
         "provider_frames": sum(int(row.get("frame_count", 0)) for row in rows),
@@ -279,6 +287,8 @@ def provider_fixture_lab_to_markdown(report: dict[str, Any]) -> str:
         f"- Generated: `{report['generated_at']}`",
         f"- Cases run: `{scorecard['total']}`",
         f"- Passed: `{scorecard['passed']}`",
+        f"- Healthy live: `{scorecard['healthy']}`",
+        f"- Simulated: `{scorecard['simulated']}`",
         f"- Degraded: `{scorecard['degraded']}`",
         f"- Failed: `{scorecard['failed']}`",
         f"- Days to expiry: `{inputs['days_to_expiry']:g}`",
@@ -291,16 +301,20 @@ def provider_fixture_lab_to_markdown(report: dict[str, Any]) -> str:
         "## Provider Scorecard",
         "",
         (
-            "| Case | Provider | Format | Symbol | Health | Messages | Frames | "
+            "| Case | Provider | Format | Symbol | Mode | Network | Health | Messages | Frames | "
             "Parse Err | Dropped | Gamma Wall | Zero Gamma |"
         ),
-        "| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        (
+            "| --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | "
+            "---: | ---: | ---: |"
+        ),
     ]
     for result in report["cases"]:
         summary = result["summary"]
         lines.append(
             f"| {summary['label']} | {summary['provider']} | "
             f"{summary['fixture_format']} | {summary['symbol']} | "
+            f"{summary['data_mode']} | {'yes' if summary['network_used'] else 'no'} | "
             f"{summary['health']} | {summary['normalized_messages']} | "
             f"{summary['frame_count']} | {summary['parse_error_count']} | "
             f"{summary['dropped_count']} | {_number(summary['gamma_wall'])} | "
@@ -316,11 +330,17 @@ def provider_fixture_lab_to_markdown(report: dict[str, Any]) -> str:
             f"- Fixture: `{summary['fixture']}`",
             f"- Description: {result['description']}",
             f"- Command: `{result['command']}`",
+            (
+                f"- Source: `{summary['source_kind']}`; network used "
+                f"`{'yes' if summary['network_used'] else 'no'}`; runtime "
+                f"`{summary['status']}` / `{summary['connection_state']}`."
+            ),
         ])
         if summary["ok"]:
             lines.extend([
                 (
-                    f"- Result: `{summary['health']}` health, "
+                    f"- Result: `{summary['mapping_status']}` mapping, "
+                    f"`{summary['health']}` health, "
                     f"`{summary['normalized_messages']}` normalized messages, "
                     f"`{summary['frame_count']}` provider frames."
                 ),
@@ -361,8 +381,13 @@ def provider_fixture_lab_to_csv(report: dict[str, Any]) -> str:
         "fixture_format",
         "fixture",
         "ok",
+        "source_kind",
+        "network_used",
+        "mapping_status",
         "health",
         "status",
+        "data_mode",
+        "connection_state",
         "spot",
         "total_net_gex",
         "gamma_wall",
@@ -389,8 +414,13 @@ def provider_fixture_lab_to_csv(report: dict[str, Any]) -> str:
             "fixture_format": summary["fixture_format"],
             "fixture": summary["fixture"],
             "ok": summary["ok"],
+            "source_kind": summary["source_kind"],
+            "network_used": summary["network_used"],
+            "mapping_status": summary["mapping_status"],
             "health": summary["health"],
             "status": summary["status"],
+            "data_mode": summary["data_mode"],
+            "connection_state": summary["connection_state"],
             "spot": summary["spot"],
             "total_net_gex": summary["total_net_gex"],
             "gamma_wall": summary["gamma_wall"],
@@ -438,11 +468,16 @@ def _failed_summary(case: ProviderFixtureCase, exc: Exception) -> dict[str, Any]
         "symbol": case.symbol,
         "fixture": _portable_path(case.fixture_path),
         "fixture_format": case.fixture_format,
+        "source_kind": "offline_provider_fixture",
+        "network_used": False,
+        "mapping_status": "failed",
         "metadata": _portable_path(case.metadata_path) if case.metadata_path else None,
         "underlying_fixture": (
             _portable_path(case.underlying_path) if case.underlying_path else None
         ),
         "status": "failed",
+        "data_mode": "REPLAY",
+        "connection_state": "DISCONNECTED",
         "health": "failed",
         "notes": [],
         "spot": 0.0,

--- a/gex_terminal/provider_injector.py
+++ b/gex_terminal/provider_injector.py
@@ -38,7 +38,7 @@ async def inject_provider_fixture(
     metadata_path: str | Path | None = None,
     underlying_path: str | Path | None = None,
 ) -> dict[str, Any]:
-    """Inject a raw provider fixture through the same consumer/engine path as live data."""
+    """Replay a raw provider fixture through the provider mapping and model path."""
     fixture = Path(fixture_path)
     if not fixture.exists():
         raise FileNotFoundError(f"Provider fixture not found: {fixture}")
@@ -48,11 +48,10 @@ async def inject_provider_fixture(
         IntradayGexEngine(multiplier=config.contract_multiplier),
         target_underlying=config.symbol,
         risk_free_rate=config.risk_free_rate,
-        data_mode="live",
+        data_mode="replay",
         stale_after_seconds=config.stale_after_seconds,
         expiry_filter=config.expiry_filter,
     )
-    consumer.mark_connected()
 
     if resolved_format == "tradovate":
         await _inject_tradovate(consumer, config, fixture, metadata_path)
@@ -87,6 +86,9 @@ async def inject_provider_fixture(
     snapshot["provider_injection"] = {
         "provider": provider,
         "fixture_format": resolved_format,
+        "source_kind": "offline_provider_fixture",
+        "network_used": False,
+        "mapping_status": "computed",
         "fixture": portable_package_data_reference(fixture),
         "metadata": (
             portable_package_data_reference(metadata_path) if metadata_path else None
@@ -109,6 +111,7 @@ def provider_injection_summary(snapshot: Mapping[str, Any]) -> str:
     metrics = snapshot.get("metrics", {})
     return "\n".join((
         f"Injected {injection.get('fixture_format', 'provider')} fixture: {injection.get('fixture')}",
+        "Source: offline provider fixture  Network used: no",
         f"Symbol: {snapshot.get('symbol')}  Spot: {float(snapshot.get('spot', 0.0)):,.2f}",
         (
             f"Gamma wall: {float(metrics.get('gamma_wall', 0.0)):,.2f}  "
@@ -122,7 +125,13 @@ def provider_injection_summary(snapshot: Mapping[str, Any]) -> str:
         ),
         (
             f"Subscription: {quality.get('subscription_status', 'unknown')}  "
-            f"Subscribed symbols: {quality.get('subscribed_symbol_count', 0)}  "
+            f"Subscribed symbols: {quality.get('subscribed_symbol_count', 0)}"
+        ),
+        (
+            f"Mapping: {injection.get('mapping_status', 'unknown')}  "
+            f"Runtime: {quality.get('status', 'unknown')}  "
+            f"Mode: {quality.get('data_mode', 'unknown')}  "
+            f"Connection: {quality.get('connection_state', 'unknown')}  "
             f"Health: {quality.get('health', 'unknown')}"
         ),
     ))

--- a/gex_terminal/tui.py
+++ b/gex_terminal/tui.py
@@ -464,18 +464,18 @@ class GexTerminalApp(App):
     ) -> None:
         updates: dict[str, float | int] = {}
         if days_to_expiry is not None:
-            updates["days_to_expiry"] = float(days_to_expiry)
+            updates["days_to_expiry"] = days_to_expiry
         if risk_free_rate is not None:
-            updates["risk_free_rate"] = float(risk_free_rate)
-            self.consumer.risk_free_rate = float(risk_free_rate)
+            updates["risk_free_rate"] = risk_free_rate
         if contract_multiplier is not None:
-            updates["contract_multiplier"] = int(contract_multiplier)
-            self.consumer.engine.multiplier = int(contract_multiplier)
+            updates["contract_multiplier"] = contract_multiplier
 
         if not updates:
             return
 
         self.config = replace(self.config, **updates)
+        self.consumer.risk_free_rate = self.config.risk_free_rate
+        self.consumer.engine.multiplier = self.config.contract_multiplier
         self._event(
             "assumptions -> "
             f"{self.config.days_to_expiry:g}DTE, "

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,91 @@
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_ENV_NAMES = (
+    "GEX_CONTRACT_MULTIPLIER",
+    "GEX_RISK_FREE_RATE",
+    "GEX_DAYS_TO_EXPIRY",
+    "GEX_REFRESH_INTERVAL_SECONDS",
+    "GEX_STALE_AFTER_SECONDS",
+    "GEX_REPLAY_DELAY_SECONDS",
+    "GEX_REPLAY_SPEED",
+    "GEX_REPLAY_MAX_GAP_SECONDS",
+    "GEX_STRICT_EVENT_TIME",
+)
+
+
+def _run_cli(*arguments: str, env_updates: dict[str, str] | None = None):
+    environment = os.environ.copy()
+    for name in CONFIG_ENV_NAMES:
+        environment.pop(name, None)
+    environment.update(env_updates or {})
+    return subprocess.run(
+        [sys.executable, "-m", "gex_terminal.cli", *arguments],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class CliConfigurationTests(unittest.TestCase):
+    def test_malformed_environment_value_is_actionable_and_never_echoed(self):
+        sentinel = "private-token-shaped-invalid-value"
+        result = _run_cli(
+            "--providers",
+            env_updates={"GEX_STALE_AFTER_SECONDS": sentinel},
+        )
+        output = result.stdout + result.stderr
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Configuration error: GEX_STALE_AFTER_SECONDS must be numeric", output)
+        self.assertNotIn(sentinel, output)
+        self.assertNotIn("Traceback", output)
+
+    def test_nonfinite_environment_value_fails_before_runtime(self):
+        result = _run_cli(
+            "--providers",
+            env_updates={"GEX_STALE_AFTER_SECONDS": "nan"},
+        )
+        output = result.stdout + result.stderr
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("GEX_STALE_AFTER_SECONDS must be finite", output)
+        self.assertNotIn("Traceback", output)
+
+    def test_malformed_cli_number_is_never_echoed_by_argparse(self):
+        sentinel = "private-token-shaped-invalid-value"
+        result = _run_cli("--refresh", sentinel, "--providers")
+        output = result.stdout + result.stderr
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("argument --refresh: must be numeric", output)
+        self.assertNotIn(sentinel, output)
+        self.assertNotIn("Traceback", output)
+
+    def test_cli_overrides_use_direct_config_range_validation(self):
+        cases = (
+            (("--refresh", "nan"), "refresh_interval_seconds must be finite"),
+            (("--multiplier", "0"), "contract_multiplier must be greater than 0"),
+            (("--replay-delay", "-1"), "replay_delay_seconds must be greater than or equal to 0"),
+            (("--replay-speed", "0"), "replay_speed must be greater than 0"),
+            (("--replay-max-gap", "-1"), "replay_max_gap_seconds must be greater than or equal to 0"),
+        )
+
+        for arguments, expected in cases:
+            with self.subTest(arguments=arguments):
+                result = _run_cli(*arguments, "--providers")
+                output = result.stdout + result.stderr
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(f"Configuration error: {expected}", output)
+                self.assertNotIn("Traceback", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feed_quality.py
+++ b/tests/test_feed_quality.py
@@ -61,6 +61,26 @@ class FeedQualitySnapshotTests(unittest.TestCase):
         self.assertEqual(snapshot.health, "degraded")
         self.assertIn("malformed payloads recorded", snapshot.notes)
 
+    def test_invalid_stale_threshold_fails_closed(self):
+        for threshold in (float("nan"), float("inf"), 0.0, -1.0):
+            with self.subTest(threshold=threshold):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "stale_after_seconds must be finite and greater than 0",
+                ):
+                    build_feed_quality_snapshot(
+                        status="LIVE",
+                        data_mode="LIVE",
+                        connection_state="CONNECTED",
+                        message_count=1,
+                        malformed_count=0,
+                        dropped_count=0,
+                        entitlement_error_count=0,
+                        last_message_age_seconds=86_400.0,
+                        last_snapshot_age_seconds=86_400.0,
+                        stale_after_seconds=threshold,
+                    )
+
 
 class ConsumerFeedQualityTests(unittest.IsolatedAsyncioTestCase):
     async def test_consumer_counts_ok_malformed_and_dropped_payloads(self):
@@ -85,6 +105,43 @@ class ConsumerFeedQualityTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(quality["dropped_count"], 1)
         self.assertEqual(quality["malformed_count"], 1)
         self.assertEqual(quality["health"], "degraded")
+
+    async def test_consumer_rejects_invalid_health_inputs_before_state_mutation(self):
+        for field, value in (
+            ("risk_free_rate", float("nan")),
+            ("stale_after_seconds", float("nan")),
+            ("stale_after_seconds", float("inf")),
+            ("stale_after_seconds", 0.0),
+        ):
+            with self.subTest(field=field, value=value):
+                with self.assertRaisesRegex(ValueError, field):
+                    StatefulGexConsumer(
+                        IntradayGexEngine(),
+                        **{field: value},
+                    )
+
+        consumer = StatefulGexConsumer(IntradayGexEngine(), data_mode="live")
+        consumer.current_spot = 5_943.25
+        with self.assertRaisesRegex(ValueError, "stale_after_seconds"):
+            await consumer.reset_state(stale_after_seconds=float("nan"))
+
+        self.assertEqual(consumer.current_spot, 5_943.25)
+        self.assertEqual(consumer.data_mode, "LIVE")
+
+    async def test_one_day_old_live_source_reports_stale_with_valid_threshold(self):
+        consumer = StatefulGexConsumer(
+            IntradayGexEngine(),
+            data_mode="live",
+            stale_after_seconds=10.0,
+        )
+        consumer.mark_connected()
+        consumer.last_message_at = time.monotonic() - 86_400.0
+
+        quality = consumer.feed_quality_snapshot(now=time.monotonic())
+
+        self.assertEqual(consumer.runtime_status, "STALE")
+        self.assertTrue(quality["stale"])
+        self.assertEqual(quality["health"], "stale")
 
 
 if __name__ == "__main__":

--- a/tests/test_gex_config.py
+++ b/tests/test_gex_config.py
@@ -1,10 +1,34 @@
 import os
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
-from gex_terminal.config import GexConfig, _load_working_directory_dotenv
+from gex_terminal.config import (
+    ConfigValidationError,
+    GexConfig,
+    _load_working_directory_dotenv,
+)
+
+
+def _config(**updates) -> GexConfig:
+    values = {
+        "symbol": "ES",
+        "symbols": ("ES",),
+        "data_mode": "replay",
+        "data_provider": "replay",
+        "contract_multiplier": 50,
+        "risk_free_rate": 0.045,
+        "days_to_expiry": 0.25,
+        "refresh_interval_seconds": 1.0,
+        "stale_after_seconds": 10.0,
+        "replay_path": "",
+        "replay_delay_seconds": 0.0,
+        "tradovate_environment": "demo",
+    }
+    values.update(updates)
+    return GexConfig(**values)
 
 
 class GexConfigTests(unittest.TestCase):
@@ -42,6 +66,99 @@ class GexConfigTests(unittest.TestCase):
 
         self.assertEqual(config.symbol, "NQ")
         self.assertEqual(config.data_mode, "replay")
+
+    def test_direct_construction_rejects_nonfinite_and_out_of_domain_values(self):
+        cases = (
+            ("contract_multiplier", 0),
+            ("contract_multiplier", -1),
+            ("contract_multiplier", 50.5),
+            ("contract_multiplier", True),
+            ("risk_free_rate", float("nan")),
+            ("risk_free_rate", float("inf")),
+            ("days_to_expiry", 0.0),
+            ("days_to_expiry", -1.0),
+            ("days_to_expiry", float("nan")),
+            ("refresh_interval_seconds", 0.0),
+            ("refresh_interval_seconds", float("inf")),
+            ("stale_after_seconds", 0.0),
+            ("stale_after_seconds", float("nan")),
+            ("replay_delay_seconds", -0.01),
+            ("replay_delay_seconds", float("inf")),
+            ("replay_speed", 0.0),
+            ("replay_speed", float("nan")),
+            ("replay_max_gap_seconds", -0.01),
+            ("replay_max_gap_seconds", float("inf")),
+            ("strict_event_time", "false"),
+        )
+
+        for field, value in cases:
+            with self.subTest(field=field, value=value):
+                with self.assertRaisesRegex(ConfigValidationError, field):
+                    _config(**{field: value})
+
+    def test_replace_uses_the_same_validation_boundary(self):
+        config = _config()
+
+        with self.assertRaisesRegex(
+            ConfigValidationError,
+            "refresh_interval_seconds must be finite",
+        ):
+            replace(config, refresh_interval_seconds=float("nan"))
+
+    def test_zero_replay_timing_and_negative_finite_rate_are_valid_boundaries(self):
+        config = _config(
+            risk_free_rate=-0.01,
+            replay_delay_seconds=0,
+            replay_max_gap_seconds=0,
+        )
+
+        self.assertEqual(config.risk_free_rate, -0.01)
+        self.assertEqual(config.replay_delay_seconds, 0.0)
+        self.assertEqual(config.replay_max_gap_seconds, 0.0)
+        self.assertEqual(config.replay_path, "")
+
+    def test_environment_numeric_and_boolean_errors_fail_closed_without_raw_values(self):
+        sentinel = "private-token-shaped-invalid-value"
+        cases = (
+            ("GEX_CONTRACT_MULTIPLIER", sentinel),
+            ("GEX_RISK_FREE_RATE", sentinel),
+            ("GEX_DAYS_TO_EXPIRY", "nan"),
+            ("GEX_REFRESH_INTERVAL_SECONDS", "inf"),
+            ("GEX_STALE_AFTER_SECONDS", sentinel),
+            ("GEX_REPLAY_DELAY_SECONDS", sentinel),
+            ("GEX_REPLAY_SPEED", "-inf"),
+            ("GEX_REPLAY_MAX_GAP_SECONDS", sentinel),
+            ("GEX_STRICT_EVENT_TIME", sentinel),
+        )
+
+        for name, value in cases:
+            with self.subTest(name=name):
+                with patch.dict(os.environ, {name: value}, clear=True):
+                    with self.assertRaises(ConfigValidationError) as caught:
+                        GexConfig.from_env()
+                self.assertIn(name, str(caught.exception))
+                self.assertNotIn(sentinel, str(caught.exception))
+
+    def test_blank_required_numeric_is_malformed_but_blank_optional_is_none(self):
+        with patch.dict(
+            os.environ,
+            {"GEX_REFRESH_INTERVAL_SECONDS": ""},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(
+                ConfigValidationError,
+                "GEX_REFRESH_INTERVAL_SECONDS must be numeric",
+            ):
+                GexConfig.from_env()
+
+        with patch.dict(
+            os.environ,
+            {"GEX_REPLAY_MAX_GAP_SECONDS": "  "},
+            clear=True,
+        ):
+            config = GexConfig.from_env()
+
+        self.assertIsNone(config.replay_max_gap_seconds)
 
 
 if __name__ == "__main__":

--- a/tests/test_offline_certification_extensions.py
+++ b/tests/test_offline_certification_extensions.py
@@ -23,6 +23,16 @@ class OfflineCertificationExtensionTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(faults["result"]["passed"])
         self.assertFalse(faults["result"]["live_transport_certified"])
         self.assertEqual(properties["result"]["predictive_validity"], "unmeasured")
+        lifecycle = next(
+            case
+            for case in faults["cases"]
+            if case["name"] == "disconnect_reconnect_subscription_failure"
+        )
+        self.assertEqual(
+            lifecycle["states"],
+            ["DISCONNECTED", "CONNECTED", "DISCONNECTED", "CONNECTED"],
+        )
+        self.assertFalse(lifecycle["live_transport_certified"])
 
     async def test_generated_performance_budget_is_explicit(self):
         report = await build_performance_report(

--- a/tests/test_provider_fixture_lab.py
+++ b/tests/test_provider_fixture_lab.py
@@ -50,7 +50,9 @@ class ProviderFixtureLabTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(report["scorecard"]["total"], len(bundled_provider_fixture_cases()))
         self.assertEqual(report["scorecard"]["passed"], len(bundled_provider_fixture_cases()))
         self.assertEqual(report["scorecard"]["failed"], 0)
-        self.assertGreaterEqual(report["scorecard"]["degraded"], 1)
+        self.assertEqual(report["scorecard"]["healthy"], 0)
+        self.assertEqual(report["scorecard"]["simulated"], 3)
+        self.assertEqual(report["scorecard"]["degraded"], 2)
 
         summaries = {
             result["name"]: result["summary"]
@@ -59,6 +61,14 @@ class ProviderFixtureLabTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(summaries["tradovate-live-sample"]["health"], "degraded")
         self.assertEqual(summaries["databento-glbx"]["symbol"], "ES")
         self.assertEqual(summaries["yfinance-etf-options"]["symbol"], "SPY")
+        for summary in summaries.values():
+            self.assertEqual(summary["source_kind"], "offline_provider_fixture")
+            self.assertFalse(summary["network_used"])
+            self.assertEqual(summary["mapping_status"], "computed")
+            self.assertEqual(summary["status"], "REPLAY")
+            self.assertEqual(summary["data_mode"], "REPLAY")
+            self.assertEqual(summary["connection_state"], "DISCONNECTED")
+            self.assertNotEqual(summary["health"], "healthy")
         self.assertIn("snapshot", report["cases"][0])
 
     async def test_formats_provider_fixture_lab_markdown_csv_and_json(self):
@@ -69,9 +79,15 @@ class ProviderFixtureLabTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("# Offline Provider Fixture Workbench", markdown)
         self.assertIn("Tradovate Live Frames", markdown)
+        self.assertIn("- Healthy live: `0`", markdown)
+        self.assertIn("- Simulated: `3`", markdown)
+        self.assertIn("| Mode | Network | Health |", markdown)
+        self.assertIn("network used `no`; runtime `REPLAY` / `DISCONNECTED`", markdown)
         self.assertIn("historical compatibility field", markdown)
         self.assertIn("not a portfolio root", markdown)
         self.assertIn("databento-glbx", {row["case"] for row in csv_rows})
+        self.assertEqual({row["network_used"] for row in csv_rows}, {"False"})
+        self.assertEqual({row["data_mode"] for row in csv_rows}, {"REPLAY"})
 
         with tempfile.TemporaryDirectory() as tmp:
             base = Path(tmp)

--- a/tests/test_provider_injector.py
+++ b/tests/test_provider_injector.py
@@ -39,6 +39,9 @@ class ProviderInjectorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(snapshot["feed_quality"]["frame_count"], 3)
         self.assertEqual(snapshot["feed_quality"]["parse_error_count"], 1)
         self.assertEqual(snapshot["feed_quality"]["dropped_count"], 1)
+        self.assertEqual(snapshot["feed_quality"]["data_mode"], "REPLAY")
+        self.assertEqual(snapshot["feed_quality"]["connection_state"], "DISCONNECTED")
+        self.assertIn("simulated local feed", snapshot["feed_quality"]["notes"])
         self.assertIn("gamma_wall", snapshot["metrics"])
         self.assertIn("Zero gamma", provider_injection_summary(snapshot))
 
@@ -77,6 +80,26 @@ class ProviderInjectorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(snapshot["spot"], 512.34)
         self.assertEqual(strikes, [505.0, 510.0, 515.0])
         self.assertEqual(snapshot["feed_quality"]["subscription_status"], "subscribed")
+        self.assertEqual(
+            snapshot["provider_injection"]["source_kind"],
+            "offline_provider_fixture",
+        )
+        self.assertIs(snapshot["provider_injection"]["network_used"], False)
+        self.assertEqual(snapshot["provider_injection"]["mapping_status"], "computed")
+        self.assertEqual(snapshot["feed_quality"]["status"], "REPLAY")
+        self.assertEqual(snapshot["feed_quality"]["data_mode"], "REPLAY")
+        self.assertEqual(snapshot["feed_quality"]["connection_state"], "DISCONNECTED")
+        self.assertEqual(snapshot["feed_quality"]["health"], "simulated")
+        self.assertIn("simulated local feed", snapshot["feed_quality"]["notes"])
+
+        summary = provider_injection_summary(snapshot)
+        self.assertIn("Source: offline provider fixture  Network used: no", summary)
+        self.assertIn("Mapping: computed", summary)
+        self.assertIn("Runtime: REPLAY", summary)
+        self.assertIn("Connection: DISCONNECTED", summary)
+        self.assertIn("Health: simulated", summary)
+        self.assertNotIn("Runtime: LIVE", summary)
+        self.assertNotIn("Health: healthy", summary)
 
     async def test_cboe_option_quotes_csv_fixture_injection(self):
         snapshot = await inject_provider_fixture(

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -304,6 +304,10 @@ class BundledResourceContractTests(unittest.TestCase):
         injection = snapshot["provider_injection"]
         serialized = json.dumps(snapshot)
 
+        self.assertEqual(injection["source_kind"], "offline_provider_fixture")
+        self.assertIs(injection["network_used"], False)
+        self.assertEqual(snapshot["feed_quality"]["status"], "REPLAY")
+        self.assertEqual(snapshot["feed_quality"]["health"], "degraded")
         self.assertEqual(
             injection["fixture"],
             "gex_terminal/data/provider_fixtures/databento_trade_records.json",

--- a/tests/test_tui_first_run.py
+++ b/tests/test_tui_first_run.py
@@ -27,6 +27,19 @@ def _config(data_mode="demo"):
 
 
 class FirstRunTerminalTests(unittest.IsolatedAsyncioTestCase):
+    async def test_invalid_assumptions_do_not_partially_mutate_runtime(self):
+        consumer = StatefulGexConsumer(IntradayGexEngine(multiplier=50), data_mode="demo")
+        config = _config()
+        app = GexTerminalApp(consumer, config)
+        with self.assertRaises(ValueError):
+            await app._apply_terminal_assumptions(risk_free_rate=float("nan"), contract_multiplier=20)
+        self.assertIs(app.config, config)
+        self.assertEqual(consumer.risk_free_rate, .045)
+        self.assertEqual(consumer.engine.multiplier, 50)
+        with self.assertRaises(ValueError):
+            await app._apply_terminal_assumptions(contract_multiplier=20.5)
+        self.assertEqual(consumer.engine.multiplier, 50)
+
     def test_demo_mode_starts_with_zero_gamma_flip_as_next_replay(self):
         consumer = StatefulGexConsumer(IntradayGexEngine(multiplier=50), data_mode="demo")
         app = GexTerminalApp(consumer=consumer, config=_config())


### PR DESCRIPTION
## Outcome

Integrate the independent H2 contributor commit 79a0a714 with H1/H3/H5 preserved.

- Strict finite/range validation for environment, direct config and replacements; safe CLI errors.
- Defensive stale thresholds and atomic UI assumption updates.
- Offline fixtures report offline/no-network origin, REPLAY/DISCONNECTED and simulated/degraded quality, not live health.
- Canonical docs, example fixture report and finding/roadmap status reconciled.

## Evidence

333 integrated tests, compilation, diff hygiene and all 7 provider-fault cases passed. Contributor branch additionally built/Twine-checked source and wheel distributions and verified installed-wheel offline injection and invalid-environment behavior outside checkout. Hosted checks re-run all packaging gates.

No live data, credentials, readiness promotion or predictive claims.
