### PR TITLE
Fix complete experiment identity verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ claimed.
 
 ### Fixed
 
+- Experiment v2 manifests now bind complete specification, profile, input,
+  implementation and result identities. Reproduction rejects inconsistent or
+  unsupported metadata and nonempty output targets; legacy v1 verification is
+  explicitly partial rather than silently promoted.
+
 - Numeric configuration now fails closed across environment, direct construction
   and CLI/UI replacement, with secret-safe errors and stale-threshold guards.
   Offline injection/fixture reports now label replay origin and no-network

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,8 +7,8 @@ This file contains planned and deferred work only. Shipped work belongs in
 belongs in [Competitive Landscape](docs/market-analysis.md).
 
 Priorities reviewed September 4, 2026 against application version `0.4.0`.
-Remaining P1 correctness work is H4 experiment identity, followed by offline
-preflight. The phases below remain
+The five P1 correctness repairs are implemented; offline preflight is next.
+The phases below remain
 conditional plans. [Application Review](docs/application-review.md) owns the
 dated health evidence and open findings.
 
@@ -21,7 +21,6 @@ an accepted work packet owns implementation status.
 
 | Order | Work | Why now | Completion evidence |
 | --- | --- | --- | --- |
-| 1 — Correctness | Close H4 experiment identity | A useful product must preserve the identity and validity of the result before adding delivery features | The accepted finding has a minimal reproduction, focused regressions, and fail-closed rejection through the public workflow |
 | 2 — Offline preflight | Add an offline `doctor` command and repair any demonstrated install/configuration failures | Users and contributors need to distinguish a broken environment from an unsupported provider | Text/JSON diagnostics work from an installed wheel outside the checkout; invalid base configuration fails; absent optional providers are explained; no connection or secret disclosure occurs |
 | 3 — Complete one research loop | Extend the existing Demo Lab with model comparison and a reproducible review receipt; add a synthetic NQ fixture where needed | Existing replay, export, journal, and experiment tools already provide most of the machinery | One authorized session yields a portable pack with source/model/quality identity, separated position models, and a reproducible result |
 | 4 — Make it usable on a fresh machine | Deliver one guided install and replay journey for the first user segment | Observed activation matters more than another command or panel | One selected distribution path passes install/upgrade checks and users complete the scoped journey without developer help |

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,10 +28,10 @@ status checklists into multiple files.
 
 An active work packet under `work-packets/` owns the status of its authorized
 change. Closed packets are historical evidence and do not make a roadmap item
-active. [GEX-HEALTH-002](work-packets/GEX-HEALTH-002.md) owns configuration and
-offline-health integration; independent experiment, preflight, and research-loop
-slices are isolated on their contributor branches. `GEX-HEALTH-001`, `003`,
-and `005` record merged identity, replay ownership, and chronology repairs.
+active. [GEX-HEALTH-004](work-packets/GEX-HEALTH-004.md) owns experiment-identity
+integration; independent preflight, support, installation and research-loop
+slices are isolated on their contributor branches. `GEX-HEALTH-001`, `002`,
+`003`, and `005` record merged correctness repairs.
 
 ## Start Here By Goal
 

--- a/docs/SAED_ADOPTION_PROFILE.md
+++ b/docs/SAED_ADOPTION_PROFILE.md
@@ -19,8 +19,8 @@
 **Adopted:** 2026-08-19
 
 **Status owner:** Each routed contributor packet owns its bounded slice;
-`GEX-HEALTH-002` owns configuration/health integration, and
-`GEX-HEALTH-001`/`003`/`005` record merged repairs. Closed `GEX-LIVE-001`
+`GEX-HEALTH-004` owns experiment-identity integration, and
+`GEX-HEALTH-001`/`002`/`003`/`005` record merged repairs. Closed `GEX-LIVE-001`
 records the `0.4.0` repository release.
 
 ## Purpose And Entry Boundary

--- a/docs/application-review.md
+++ b/docs/application-review.md
@@ -151,7 +151,16 @@ the consumer. A public interactive-path regression must prove that no prior
 session record arrives after the new session is selected, including delayed
 and event-clock replay. Existing idle-consumer switch tests are insufficient.
 
-### H4 — P1: Reproduction accepts inconsistent experiment metadata
+### H4 — Resolved: Experiment reproduction validates complete identity
+
+Repair: versioned v2 manifests bind the full normalized specification, profile,
+input, implementation, evidence policy and semantic result. Reproduction rejects
+inconsistent or unsupported records before execution and refuses nonempty output
+directories. V1 records retain an explicit `legacy_partial` ceiling rather than
+claiming complete historical identity. Focused tamper, compatibility and
+no-overwrite regressions are recorded in
+[GEX-HEALTH-004](work-packets/GEX-HEALTH-004.md). The following describes the
+original defect; unkeyed hashes still do not establish authenticity.
 
 [`reproduce_experiment`](../gex_terminal/experiment_manifest.py) verifies the
 input digest and resulting report digest, but does not compare the embedded

--- a/docs/research-governance.md
+++ b/docs/research-governance.md
@@ -13,14 +13,16 @@ Four contracts keep research decisions inspectable:
    models, position-model order, directional coverage, and underlying-age gates.
 2. An **experiment spec** fixes the workflow, input, point-in-time cutoff, data
    split, outcome definition, cost assumptions, and inline model profile.
-3. An **experiment manifest** records package/Python versions and SHA-256
-   identities for the input, profile, and semantic result.
+3. An **experiment manifest** records package/Python/runtime versions and
+   SHA-256 identities for the complete normalized spec, inline profile, input,
+   producing implementation, and semantic result.
 4. A **research corpus** records immutable dataset IDs, source digests, rights,
    redaction, split, outcome, and cost metadata in an append-only hash chain.
 
-The schemas are versioned. Unknown schemas or unsupported model ladders fail
-closed. `predictive_validity` is fixed to `unmeasured` in these offline
-contracts.
+The schemas are versioned. Unknown schemas, runtime contracts, producer
+versions, or unsupported model ladders fail closed. Compatibility is declared
+explicitly; it is not inferred from package-version ordering.
+`predictive_validity` is fixed to `unmeasured` in these offline contracts.
 
 ## Run And Reproduce An Experiment
 
@@ -34,9 +36,41 @@ gex-terminal experiment-reproduce \
   /tmp/gex-experiment/manifest.json /tmp/gex-reproduction
 ```
 
-Reproduction verifies the original input digest and compares a semantic result
-digest that excludes generation timestamps only. A changed input or
-decision-relevant output fails the command.
+New runs emit experiment-manifest v2. Before executing a reproduction, the v2
+reader validates the embedded profile identity, the complete normalized spec
+identity (including split, outcome, costs, and cutoff), mirrored metadata,
+input identity, evidence policy, and producer/runtime compatibility. It then
+compares a semantic result digest that excludes generation timestamps only. A
+changed identity, input, or decision-relevant output fails the command.
+
+The stable experiment identity excludes `generated_at`, the manifest-level
+`source_root` and `spec_reference`, report location, and
+reproduction-operation status. Those fields are location or operation
+metadata, not permission to alter the experiment. The spec's declared input
+reference remains bound; a later rights-aware portable pack must give that
+input a stable logical reference rather than silently rewriting an existing
+experiment.
+
+Run and reproduction targets must be absent or empty. A nonempty directory is
+rejected before the workflow runs, and report/manifest files are created
+exclusively so an existing local artifact is never overwritten.
+
+Legacy v1 manifests from the explicitly supported `0.3.0` and `0.4.0`
+producers remain readable when every field v1 recorded is internally
+consistent. Successful reproduction also requires the current workflow to
+match the recorded semantic result. Additive report fields or corrected
+chronology can therefore make an older result fail; reader compatibility is
+not a promise to preserve a stale numerical hash. Their reproduction status is
+`legacy_partial`: v1 can validate its profile, input, implementation, and
+result, but it stored no complete-spec digest and therefore cannot
+independently prove that split, outcome, or costs were never relabeled. A
+successful legacy reproduction writes a fresh v2 artifact with lineage to the
+exact source-manifest bytes; it never rewrites or upgrades the source record in
+place.
+
+These unkeyed hashes establish internal consistency and content identity, not
+authenticity. Deliberate-tamper protection requires a separate signature or
+external anchor and is not claimed here.
 
 ## Register And Verify A Corpus
 

--- a/docs/work-packets/GEX-HEALTH-002.md
+++ b/docs/work-packets/GEX-HEALTH-002.md
@@ -6,7 +6,7 @@ method_version: "1.3"
 profile: gex-terminal-team-v1
 adoption_context: team
 change_rigor: L3
-status: "Ready for integration — branch evidence passed"
+status: closed
 packet_owner: project maintainer
 spec_steward: implementation agent
 architecture_authority: project maintainer
@@ -170,8 +170,9 @@ None.
 Integration at `main@813bb24` preserved H1 multiplier identity, H3 writer
 ownership, and H5 chronology. An additional regression validates UI assumption
 changes before publishing engine mutations. All 333 integrated tests,
-compilation, diff hygiene, and the 7/7 provider-fault gate passed. Hosted checks
-and clean-main verification remain pending at this integration commit.
+compilation, diff hygiene, and the 7/7 provider-fault gate passed. PR #23 merged
+as `51ad3a2` after all four hosted Python 3.11/3.12 checks passed. Clean merged
+main passed all 333 tests and compilation. No live-readiness status changed.
 
 Repository evidence on the isolated contributor branch:
 

--- a/docs/work-packets/GEX-HEALTH-004.md
+++ b/docs/work-packets/GEX-HEALTH-004.md
@@ -1,0 +1,102 @@
+# GEX-HEALTH-004 — Experiment Identity
+
+```yaml
+method: saed
+method_version: "1.3"
+profile: gex-terminal-team-v1
+change_rigor: L3
+status: ready_for_integration
+packet_owner: project maintainer
+spec_steward: implementation agent
+evidence_reviewer: pull-request reviewer and hosted CI
+baseline: main@4c79f1f
+branch: codex/gex-health-004-experiment-identity
+created: 2026-09-04
+```
+
+## Authority and scope
+
+The maintainer authorized the offline roadmap through the live-data boundary,
+including independently mergeable correctness repairs and contributor review.
+This slice closes H4 from the application review by making experiment metadata
+part of a validated, versioned identity. It does not add live access, sign or
+anchor artifacts, package a portable input, promote predictive validity, or
+claim protection from deliberate tampering.
+
+Own the experiment manifest implementation and tests, the minimum CLI status
+needed to expose legacy identity limits, and the research-governance contract.
+Roadmap, documentation indexes, changelog, release version, and portable pack
+integration remain with the coordinating workstream.
+
+## Contract and compatibility
+
+Adopt INV-01 through INV-08 of the adoption profile and preserve model math,
+workflow behavior, semantic-result hashing, and local artifact ownership.
+
+- New runs emit `gex-terminal.experiment-manifest.v2`. The normalized complete
+  experiment spec, inline profile, input identity, producer implementation, and
+  semantic result are bound by canonical SHA-256 identities.
+- Manifest-local `source_root`/`spec_reference` locations, generation time, and
+  reproduction-operation status are excluded from the stable experiment
+  identity. The declared spec input reference remains bound; a later portable
+  pack must give it a stable logical reference rather than silently rewriting
+  an existing experiment.
+- The v2 producer/reader contract is
+  `gex-terminal.experiment-runtime.v1`. Package version `0.4.0` is explicitly
+  supported; future releases must deliberately update compatibility rather
+  than infer it from semantic version numbers.
+- Existing v1 manifests produced by package versions `0.3.0` and `0.4.0`
+  remain readable when every identity they actually recorded is consistent.
+  Successful reproduction still requires the current workflow to match the
+  recorded semantic result; additive report fields or corrected chronology may
+  therefore make an older result fail rather than be silently reinterpreted.
+  V1 reports `legacy_partial`, because it cannot independently prove that
+  split, outcome, or cost metadata was never relabeled.
+- Unknown manifest, spec, model, runtime-contract, or producer versions fail
+  before experiment execution. A legacy record is never silently promoted to
+  complete historical identity assurance.
+
+## Acceptance
+
+- An unchanged v2 experiment reproduces with complete identity validation and
+  the same semantic result.
+- Profile, split, outcome, cost, input reference/digest/size, mirrored workflow
+  or experiment ID, implementation, result, or stored identity changes fail at
+  their owning validation gate.
+- Metadata and implementation failures occur before a workflow is invoked or
+  output is created. Result drift still fails after deterministic execution.
+- A nonempty output directory fails before execution, including an attempt to
+  reproduce into the source artifact directory; existing report and manifest
+  bytes remain untouched.
+- Known, internally consistent v1 manifests reproduce with an explicit
+  `legacy_partial` status and v2 lineage to the exact source-manifest bytes.
+  A stale v1 profile hash or unknown producer version fails closed.
+- Canonical identity rejects malformed digests and non-finite values. Hashes
+  establish internal consistency only; authenticity remains a separate future
+  signing or anchoring decision.
+- Focused tests, the full unit suite, source compilation, and diff hygiene pass
+  before the branch is handed back for independent merge.
+
+## Recovery
+
+No stored artifact is migrated or overwritten in place. Run and reproduction
+targets must be absent or empty, and artifact files use exclusive creation. The
+source manifest remains operator-owned. Reverting the eventual merge restores
+the v1 writer/reader. A v1 record from an undeclared producer must be reproduced
+with its originating release or rerun from its original spec and input as a new
+v2 experiment.
+
+## Evidence
+
+- `tests.test_experiment_manifest`: 15 tests passed, including complete v2
+  identity, legacy partial identity, predictive-validity and unknown-field
+  rejection, result/input drift, CLI status, and no-overwrite coverage.
+- Full unit discovery: 308 tests passed with no failures.
+- Source compilation for `main.py`, `gex_terminal`, and `tests` completed with
+  no errors; `git diff --check` passed.
+- An out-of-worktree public CLI run/reproduce smoke completed with
+  `matched=True` and `identity_validation=complete` when the isolated source
+  was selected explicitly.
+- Verification used packaged offline fixtures only. No provider credentials,
+  live market connection, signing authority, or empirical-validity claim was
+  exercised.

--- a/docs/work-packets/GEX-HEALTH-004.md
+++ b/docs/work-packets/GEX-HEALTH-004.md
@@ -88,6 +88,10 @@ v2 experiment.
 
 ## Evidence
 
+Integration on `main@51ad3a2` preserves all four preceding correctness repairs.
+All 344 integrated tests, source compilation and diff hygiene pass. Hosted
+checks and clean-main verification are required before closing this packet.
+
 - `tests.test_experiment_manifest`: 15 tests passed, including complete v2
   identity, legacy partial identity, predictive-validity and unknown-field
   rejection, result/input drift, CLI status, and no-overwrite coverage.

--- a/gex_terminal/cli.py
+++ b/gex_terminal/cli.py
@@ -979,7 +979,9 @@ async def experiment_reproduce_command(args: argparse.Namespace) -> None:
         raise SystemExit(str(exc)) from exc
     print(
         f"Reproduced experiment {manifest['experiment_id']} "
-        f"(matched={manifest['reproduction']['matched']}, predictive_validity=unmeasured)"
+        f"(matched={manifest['reproduction']['matched']}, "
+        f"identity_validation={manifest['reproduction']['identity_validation']}, "
+        "predictive_validity=unmeasured)"
     )
 
 

--- a/gex_terminal/experiment_manifest.py
+++ b/gex_terminal/experiment_manifest.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import platform
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
@@ -20,11 +22,143 @@ from gex_terminal.price_action_validation import load_price_action_report
 
 
 EXPERIMENT_SPEC_SCHEMA = "gex-terminal.experiment-spec.v1"
-EXPERIMENT_MANIFEST_SCHEMA = "gex-terminal.experiment-manifest.v1"
+EXPERIMENT_MANIFEST_SCHEMA_V1 = "gex-terminal.experiment-manifest.v1"
+EXPERIMENT_MANIFEST_SCHEMA_V2 = "gex-terminal.experiment-manifest.v2"
+EXPERIMENT_MANIFEST_SCHEMA = EXPERIMENT_MANIFEST_SCHEMA_V2
+EXPERIMENT_IDENTITY_SCHEMA = "gex-terminal.experiment-identity.v1"
+EXPERIMENT_CANONICALIZATION = "gex-terminal.canonical-json.v1"
+EXPERIMENT_RUNTIME_CONTRACT = "gex-terminal.experiment-runtime.v1"
+EXPERIMENT_EVIDENCE_POLICY = "gex-terminal.offline-evidence-ceiling.v1"
+EXPERIMENT_EVIDENCE_CEILING = (
+    "reproducible offline software result only; no live-provider, dealer-inventory, "
+    "predictive, execution, or profitability claim"
+)
 EXPERIMENT_WORKFLOWS = {
     "databento_replay",
     "position_model_compare",
     "price_action_evaluate",
+}
+
+# Compatibility is explicit rather than inferred from package-version ordering.
+# A future release must deliberately extend these declarations or introduce a
+# new runtime contract.
+SUPPORTED_EXPERIMENT_PRODUCERS = {
+    EXPERIMENT_MANIFEST_SCHEMA_V1: frozenset({"0.3.0", "0.4.0"}),
+    EXPERIMENT_MANIFEST_SCHEMA_V2: frozenset({"0.4.0"}),
+}
+SUPPORTED_EXPERIMENT_READERS = {
+    EXPERIMENT_RUNTIME_CONTRACT: frozenset({"0.4.0"}),
+}
+
+_PACKAGE_NAME = "gex-terminal"
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_EXPERIMENT_SPEC_FIELDS = frozenset(
+    {
+        "schema",
+        "experiment_id",
+        "workflow",
+        "input",
+        "model_profile",
+        "as_of",
+        "split",
+        "outcome_definition",
+        "cost_assumptions",
+        "predictive_validity",
+    }
+)
+_MODEL_PROFILE_FIELDS = frozenset(
+    {
+        "schema",
+        "profile_id",
+        "model_version",
+        "symbol",
+        "contract_multiplier",
+        "risk_free_rate",
+        "days_to_expiry",
+        "expiry_filter",
+        "pricing",
+        "position_models",
+        "minimum_directional_coverage",
+        "maximum_underlying_age_seconds",
+        "predictive_validity",
+    }
+)
+_MANIFEST_FIELDS = {
+    EXPERIMENT_MANIFEST_SCHEMA_V1: frozenset(
+        {
+            "schema",
+            "experiment_id",
+            "generated_at",
+            "workflow",
+            "implementation",
+            "spec_reference",
+            "source_root",
+            "experiment_spec",
+            "profile_sha256",
+            "input",
+            "result",
+            "reproduction",
+            "evidence_ceiling",
+        }
+    ),
+    EXPERIMENT_MANIFEST_SCHEMA_V2: frozenset(
+        {
+            "schema",
+            "experiment_id",
+            "generated_at",
+            "workflow",
+            "implementation",
+            "spec_reference",
+            "source_root",
+            "experiment_spec",
+            "identity",
+            "input",
+            "result",
+            "reproduction",
+            "evidence_policy",
+            "evidence_ceiling",
+        }
+    ),
+}
+_IMPLEMENTATION_FIELDS = {
+    EXPERIMENT_MANIFEST_SCHEMA_V1: frozenset({"package", "version", "python"}),
+    EXPERIMENT_MANIFEST_SCHEMA_V2: frozenset(
+        {
+            "package",
+            "version",
+            "python",
+            "runtime_contract",
+        }
+    ),
+}
+_IDENTITY_FIELDS = frozenset(
+    {
+        "schema",
+        "canonicalization",
+        "profile_sha256",
+        "experiment_spec_sha256",
+        "experiment_sha256",
+    }
+)
+_INPUT_FIELDS = frozenset({"reference", "sha256", "bytes"})
+_RESULT_FIELDS = frozenset({"path", "semantic_sha256", "predictive_validity"})
+_REPRODUCTION_FIELDS = {
+    EXPERIMENT_MANIFEST_SCHEMA_V1: frozenset(
+        {
+            "expected_semantic_sha256",
+            "matched",
+        }
+    ),
+    EXPERIMENT_MANIFEST_SCHEMA_V2: frozenset(
+        {
+            "expected_semantic_sha256",
+            "matched",
+            "identity_validation",
+            "source_manifest_schema",
+            "source_manifest_sha256",
+            "implementation_compatibility",
+        }
+    ),
 }
 
 
@@ -46,25 +180,25 @@ async def reproduce_experiment(
     manifest_path: str | Path, output_dir: str | Path
 ) -> dict[str, Any]:
     manifest_source = Path(manifest_path).resolve()
-    manifest = json.loads(manifest_source.read_text(encoding="utf-8"))
-    if not isinstance(manifest, Mapping) or manifest.get("schema") != EXPERIMENT_MANIFEST_SCHEMA:
-        raise ValueError("experiment manifest schema is unsupported")
-    spec = manifest.get("experiment_spec")
-    if not isinstance(spec, Mapping):
-        raise ValueError("experiment manifest is missing experiment_spec")
-    source_root = Path(str(manifest.get("source_root") or ""))
+    manifest_bytes = manifest_source.read_bytes()
+    try:
+        manifest_text = manifest_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("experiment manifest must be UTF-8 JSON") from exc
+    manifest = _parse_json_object(manifest_text, "experiment manifest")
+    expected = _validate_recorded_manifest(
+        manifest, hashlib.sha256(manifest_bytes).hexdigest()
+    )
+    source_root = Path(expected["source_root"])
     if not source_root.is_absolute():
         source_root = (manifest_source.parent / source_root).resolve()
-    result = await _execute_experiment(
-        dict(spec),
+    return await _execute_experiment(
+        expected["experiment_spec"],
         source_root=source_root,
-        spec_reference=str(manifest.get("spec_reference") or manifest_source),
+        spec_reference=expected["spec_reference"],
         output_dir=output_dir,
-        expected=manifest,
+        expected=expected,
     )
-    if not result["reproduction"]["matched"]:
-        raise ValueError("experiment reproduction did not match the recorded semantic result")
-    return result
 
 
 async def _execute_experiment(
@@ -75,12 +209,22 @@ async def _execute_experiment(
     output_dir: str | Path,
     expected: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
+    target = _validate_output_target(output_dir)
     normalized = _validate_spec(spec)
+    profile = normalized["model_profile"]
+    implementation = _current_implementation()
+    profile_digest = canonical_sha256(profile)
+    spec_digest = canonical_sha256(normalized)
+
     input_path = _resolve_reference(source_root, normalized["input"])
     input_digest = _file_digest(input_path)
-    if expected is not None and input_digest != expected.get("input", {}).get("sha256"):
-        raise ValueError("experiment input digest changed since the recorded run")
-    profile = normalized["model_profile"]
+    input_bytes = input_path.stat().st_size
+    if expected is not None:
+        if not hmac.compare_digest(input_digest, expected["input_sha256"]):
+            raise ValueError("experiment input digest changed since the recorded run")
+        if input_bytes != expected["input_bytes"]:
+            raise ValueError("experiment input byte count changed since the recorded run")
+
     config = config_from_model_profile(profile)
     workflow = normalized["workflow"]
     if workflow == "databento_replay":
@@ -94,53 +238,92 @@ async def _execute_experiment(
     else:
         report = load_price_action_report(input_path)
     _enforce_as_of(workflow, normalized["as_of"], report)
+    if _file_digest(input_path) != input_digest or input_path.stat().st_size != input_bytes:
+        raise ValueError("experiment input changed while the workflow was executing")
     semantic_digest = semantic_sha256(report)
+    expected_digest = expected["result_sha256"] if expected is not None else None
+    if expected_digest is not None and not hmac.compare_digest(
+        semantic_digest, expected_digest
+    ):
+        raise ValueError("experiment reproduction did not match the recorded semantic result")
+
     generated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    target = Path(output_dir)
-    target.mkdir(parents=True, exist_ok=True)
-    report_path = target / "report.json"
-    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    expected_digest = (
-        expected.get("result", {}).get("semantic_sha256") if expected is not None else None
+    identity = {
+        "schema": EXPERIMENT_IDENTITY_SCHEMA,
+        "canonicalization": EXPERIMENT_CANONICALIZATION,
+        "profile_sha256": profile_digest,
+        "experiment_spec_sha256": spec_digest,
+    }
+    identity["experiment_sha256"] = canonical_sha256(
+        _experiment_identity_payload(
+            profile_sha256=profile_digest,
+            experiment_spec_sha256=spec_digest,
+            input_sha256=input_digest,
+            input_bytes=input_bytes,
+            implementation=implementation,
+            result_sha256=semantic_digest,
+        )
     )
+    reproduction = {
+        "expected_semantic_sha256": expected_digest,
+        "matched": expected_digest is None or expected_digest == semantic_digest,
+        "identity_validation": (
+            expected["identity_validation"] if expected is not None else "complete"
+        ),
+        "source_manifest_schema": (
+            expected["manifest_schema"] if expected is not None else None
+        ),
+        "source_manifest_sha256": (
+            expected["source_manifest_sha256"] if expected is not None else None
+        ),
+        "implementation_compatibility": (
+            expected["implementation_compatibility"] if expected is not None else None
+        ),
+    }
     manifest = {
         "schema": EXPERIMENT_MANIFEST_SCHEMA,
         "experiment_id": normalized["experiment_id"],
         "generated_at": generated_at,
         "workflow": workflow,
-        "implementation": {
-            "package": "gex-terminal",
-            "version": __version__,
-            "python": platform.python_version(),
-        },
+        "implementation": implementation,
         "spec_reference": spec_reference,
         "source_root": str(source_root),
         "experiment_spec": normalized,
-        "profile_sha256": semantic_sha256(profile),
+        "identity": identity,
         "input": {
             "reference": normalized["input"],
             "sha256": input_digest,
-            "bytes": input_path.stat().st_size,
+            "bytes": input_bytes,
         },
         "result": {
             "path": "report.json",
             "semantic_sha256": semantic_digest,
             "predictive_validity": "unmeasured",
         },
-        "reproduction": {
-            "expected_semantic_sha256": expected_digest,
-            "matched": expected_digest is None or expected_digest == semantic_digest,
-        },
-        "evidence_ceiling": (
-            "reproducible offline software result only; no live-provider, dealer-inventory, "
-            "predictive, execution, or profitability claim"
-        ),
+        "reproduction": reproduction,
+        "evidence_policy": EXPERIMENT_EVIDENCE_POLICY,
+        "evidence_ceiling": EXPERIMENT_EVIDENCE_CEILING,
     }
+
+    _validate_output_target(target)
+    target.mkdir(parents=True, exist_ok=True)
+    report_path = target / "report.json"
+    _write_new_json(report_path, report)
     manifest_path = target / "manifest.json"
-    manifest_path.write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    _write_new_json(manifest_path, manifest)
     return manifest
+
+
+def canonical_sha256(value: Any) -> str:
+    """Hash every field of a canonical JSON-compatible identity value."""
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def semantic_sha256(value: Any) -> str:
@@ -165,13 +348,326 @@ def _without_volatile_fields(value: Any) -> Any:
 
 
 def _load_spec(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    return _validate_spec(_load_json_object(path, "experiment spec"))
+
+
+def _load_json_object(path: Path, label: str) -> dict[str, Any]:
+    return _parse_json_object(path.read_text(encoding="utf-8"), label)
+
+
+def _parse_json_object(text: str, label: str) -> dict[str, Any]:
+    payload = json.loads(
+        text,
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_nonfinite_constant,
+    )
     if not isinstance(payload, Mapping):
-        raise ValueError("experiment spec must be a JSON object")
-    return _validate_spec(payload)
+        raise ValueError(f"{label} must be a JSON object")
+    return dict(payload)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key is unsupported: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_constant(value: str) -> Any:
+    raise ValueError(f"non-finite JSON value is unsupported: {value}")
+
+
+def _validate_recorded_manifest(
+    manifest: Mapping[str, Any], source_manifest_sha256: str
+) -> dict[str, Any]:
+    schema = manifest.get("schema")
+    if not isinstance(schema, str) or schema not in {
+        EXPERIMENT_MANIFEST_SCHEMA_V1,
+        EXPERIMENT_MANIFEST_SCHEMA_V2,
+    }:
+        raise ValueError(f"unsupported experiment manifest schema: {schema}")
+    _reject_unknown_fields(manifest, _MANIFEST_FIELDS[schema], "experiment manifest")
+
+    common = _validate_manifest_common(manifest, str(schema))
+    profile = common["experiment_spec"]["model_profile"]
+    if schema == EXPERIMENT_MANIFEST_SCHEMA_V1:
+        recorded_profile_sha256 = _required_sha256(
+            manifest.get("profile_sha256"), "experiment profile_sha256"
+        )
+        expected_profile_sha256 = semantic_sha256(profile)
+        if not hmac.compare_digest(
+            recorded_profile_sha256, expected_profile_sha256
+        ):
+            raise ValueError(
+                "experiment profile identity does not match the embedded model_profile"
+            )
+        identity_validation = "legacy_partial"
+    else:
+        _validate_v2_identity(manifest, common)
+        identity_validation = "complete"
+
+    return {
+        **common,
+        "manifest_schema": schema,
+        "identity_validation": identity_validation,
+        "source_manifest_sha256": source_manifest_sha256,
+    }
+
+
+def _validate_manifest_common(
+    manifest: Mapping[str, Any], schema: str
+) -> dict[str, Any]:
+    raw_spec = _required_mapping(
+        manifest.get("experiment_spec"), "experiment manifest experiment_spec"
+    )
+    spec = _validate_spec(raw_spec)
+    if manifest.get("experiment_id") != spec["experiment_id"]:
+        raise ValueError("experiment manifest experiment_id does not match experiment_spec")
+    if manifest.get("workflow") != spec["workflow"]:
+        raise ValueError("experiment manifest workflow does not match experiment_spec")
+
+    input_record = _required_mapping(manifest.get("input"), "experiment manifest input")
+    _reject_unknown_fields(input_record, _INPUT_FIELDS, "experiment input")
+    input_reference = _required_text(
+        input_record.get("reference"), "experiment input reference"
+    )
+    if input_reference != spec["input"]:
+        raise ValueError("experiment input reference does not match experiment_spec")
+    input_sha256 = _required_sha256(
+        input_record.get("sha256"), "experiment input sha256"
+    )
+    input_bytes = _nonnegative_integer(
+        input_record.get("bytes"), "experiment input bytes"
+    )
+
+    result = _required_mapping(manifest.get("result"), "experiment manifest result")
+    _reject_unknown_fields(result, _RESULT_FIELDS, "experiment result")
+    _required_text(result.get("path"), "experiment result path")
+    result_sha256 = _required_sha256(
+        result.get("semantic_sha256"), "experiment result semantic_sha256"
+    )
+    if result.get("predictive_validity") != "unmeasured":
+        raise ValueError("experiment result predictive_validity must be unmeasured")
+
+    implementation, compatibility = _validate_implementation(
+        manifest.get("implementation"), schema
+    )
+    source_root = _required_text(manifest.get("source_root"), "experiment source_root")
+    spec_reference = _required_text(
+        manifest.get("spec_reference"), "experiment spec_reference"
+    )
+    if manifest.get("evidence_ceiling") != EXPERIMENT_EVIDENCE_CEILING:
+        raise ValueError("experiment evidence ceiling is unsupported")
+    reproduction = _required_mapping(
+        manifest.get("reproduction"), "experiment manifest reproduction"
+    )
+    _reject_unknown_fields(
+        reproduction,
+        _REPRODUCTION_FIELDS[schema],
+        "experiment reproduction",
+    )
+
+    return {
+        "experiment_spec": spec,
+        "source_root": source_root,
+        "spec_reference": spec_reference,
+        "input_sha256": input_sha256,
+        "input_bytes": input_bytes,
+        "result_sha256": result_sha256,
+        "implementation": implementation,
+        "implementation_compatibility": compatibility,
+    }
+
+
+def _validate_v2_identity(
+    manifest: Mapping[str, Any], common: Mapping[str, Any]
+) -> None:
+    if manifest.get("evidence_policy") != EXPERIMENT_EVIDENCE_POLICY:
+        raise ValueError("experiment evidence policy is unsupported")
+    identity = _required_mapping(manifest.get("identity"), "experiment identity")
+    _reject_unknown_fields(identity, _IDENTITY_FIELDS, "experiment identity")
+    if identity.get("schema") != EXPERIMENT_IDENTITY_SCHEMA:
+        raise ValueError(f"unsupported experiment identity schema: {identity.get('schema')}")
+    if identity.get("canonicalization") != EXPERIMENT_CANONICALIZATION:
+        raise ValueError(
+            "unsupported experiment identity canonicalization: "
+            f"{identity.get('canonicalization')}"
+        )
+
+    profile_sha256 = _required_sha256(
+        identity.get("profile_sha256"), "experiment identity profile_sha256"
+    )
+    expected_profile_sha256 = canonical_sha256(
+        common["experiment_spec"]["model_profile"]
+    )
+    if not hmac.compare_digest(profile_sha256, expected_profile_sha256):
+        raise ValueError(
+            "experiment profile identity does not match the embedded model_profile"
+        )
+
+    spec_sha256 = _required_sha256(
+        identity.get("experiment_spec_sha256"),
+        "experiment identity experiment_spec_sha256",
+    )
+    expected_spec_sha256 = canonical_sha256(common["experiment_spec"])
+    if not hmac.compare_digest(spec_sha256, expected_spec_sha256):
+        raise ValueError(
+            "experiment spec identity does not match the embedded experiment_spec"
+        )
+
+    experiment_sha256 = _required_sha256(
+        identity.get("experiment_sha256"), "experiment identity experiment_sha256"
+    )
+    expected_experiment_sha256 = canonical_sha256(
+        _experiment_identity_payload(
+            profile_sha256=profile_sha256,
+            experiment_spec_sha256=spec_sha256,
+            input_sha256=common["input_sha256"],
+            input_bytes=common["input_bytes"],
+            implementation=common["implementation"],
+            result_sha256=common["result_sha256"],
+        )
+    )
+    if not hmac.compare_digest(experiment_sha256, expected_experiment_sha256):
+        raise ValueError("experiment identity does not match the recorded fields")
+
+
+def _experiment_identity_payload(
+    *,
+    profile_sha256: str,
+    experiment_spec_sha256: str,
+    input_sha256: str,
+    input_bytes: int,
+    implementation: Mapping[str, Any],
+    result_sha256: str,
+) -> dict[str, Any]:
+    return {
+        "schema": EXPERIMENT_IDENTITY_SCHEMA,
+        "canonicalization": EXPERIMENT_CANONICALIZATION,
+        "manifest_schema": EXPERIMENT_MANIFEST_SCHEMA_V2,
+        "profile_sha256": profile_sha256,
+        "experiment_spec_sha256": experiment_spec_sha256,
+        "input": {"sha256": input_sha256, "bytes": input_bytes},
+        "implementation": dict(implementation),
+        "result": {
+            "semantic_sha256": result_sha256,
+            "predictive_validity": "unmeasured",
+        },
+        "evidence_policy": EXPERIMENT_EVIDENCE_POLICY,
+    }
+
+
+def _current_implementation() -> dict[str, str]:
+    implementation = {
+        "package": _PACKAGE_NAME,
+        "version": __version__,
+        "python": platform.python_version(),
+        "runtime_contract": EXPERIMENT_RUNTIME_CONTRACT,
+    }
+    normalized, _ = _validate_implementation(
+        implementation, EXPERIMENT_MANIFEST_SCHEMA_V2
+    )
+    return normalized
+
+
+def _validate_implementation(
+    value: Any, manifest_schema: str
+) -> tuple[dict[str, str], dict[str, Any]]:
+    implementation = _required_mapping(value, "experiment implementation")
+    _reject_unknown_fields(
+        implementation,
+        _IMPLEMENTATION_FIELDS[manifest_schema],
+        "experiment implementation",
+    )
+    package = _required_text(
+        implementation.get("package"), "experiment implementation package"
+    )
+    version = _required_text(
+        implementation.get("version"), "experiment implementation version"
+    )
+    python_version = _required_text(
+        implementation.get("python"), "experiment implementation python"
+    )
+    if package != _PACKAGE_NAME:
+        raise ValueError(f"unsupported experiment implementation package: {package}")
+    supported_producers = SUPPORTED_EXPERIMENT_PRODUCERS.get(manifest_schema)
+    if supported_producers is None or version not in supported_producers:
+        raise ValueError(
+            "unsupported experiment producer version for "
+            f"{manifest_schema}: {version}"
+        )
+
+    if manifest_schema == EXPERIMENT_MANIFEST_SCHEMA_V2:
+        runtime_contract = _required_text(
+            implementation.get("runtime_contract"),
+            "experiment implementation runtime_contract",
+        )
+    else:
+        runtime_contract = EXPERIMENT_RUNTIME_CONTRACT
+    if runtime_contract not in SUPPORTED_EXPERIMENT_READERS:
+        raise ValueError(
+            f"unsupported experiment runtime contract: {runtime_contract}"
+        )
+    supported_readers = SUPPORTED_EXPERIMENT_READERS[runtime_contract]
+    if __version__ not in supported_readers:
+        raise ValueError(
+            "current package version is not declared compatible with experiment "
+            f"runtime {runtime_contract}: {__version__}"
+        )
+
+    normalized = {
+        "package": package,
+        "version": version,
+        "python": python_version,
+    }
+    if manifest_schema == EXPERIMENT_MANIFEST_SCHEMA_V2:
+        normalized["runtime_contract"] = runtime_contract
+    return normalized, {
+        "status": "compatible",
+        "runtime_contract": runtime_contract,
+        "recorded_package": package,
+        "recorded_version": version,
+        "current_package": _PACKAGE_NAME,
+        "current_version": __version__,
+    }
+
+
+def _required_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _reject_unknown_fields(
+    value: Mapping[str, Any], allowed: frozenset[str], label: str
+) -> None:
+    unknown = sorted(str(key) for key in value if key not in allowed)
+    if unknown:
+        raise ValueError(f"{label} contains unsupported fields: {', '.join(unknown)}")
+
+
+def _required_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def _required_sha256(value: Any, label: str) -> str:
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _nonnegative_integer(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{label} must be a non-negative integer")
+    return value
 
 
 def _validate_spec(spec: Mapping[str, Any]) -> dict[str, Any]:
+    _reject_unknown_fields(spec, _EXPERIMENT_SPEC_FIELDS, "experiment spec")
     if spec.get("schema") != EXPERIMENT_SPEC_SCHEMA:
         raise ValueError(f"experiment spec schema must be {EXPERIMENT_SPEC_SCHEMA}")
     experiment_id = str(spec.get("experiment_id") or "").strip()
@@ -186,6 +682,9 @@ def _validate_spec(spec: Mapping[str, Any]) -> dict[str, Any]:
     raw_profile = spec.get("model_profile")
     if not isinstance(raw_profile, Mapping):
         raise ValueError("experiment spec requires an inline model_profile")
+    _reject_unknown_fields(
+        raw_profile, _MODEL_PROFILE_FIELDS, "experiment model_profile"
+    )
     profile = validate_model_profile(raw_profile)
     split = str(spec.get("split") or "unspecified").strip().lower()
     if split not in {"train", "calibration", "test", "unspecified"}:
@@ -199,6 +698,11 @@ def _validate_spec(spec: Mapping[str, Any]) -> dict[str, Any]:
     as_of = _timezone_aware_timestamp(spec.get("as_of"), "experiment as_of")
     if as_of is None:
         raise ValueError("experiment spec requires as_of")
+    if (
+        "predictive_validity" in spec
+        and spec.get("predictive_validity") != "unmeasured"
+    ):
+        raise ValueError("experiment spec predictive_validity must be unmeasured")
     return {
         "schema": EXPERIMENT_SPEC_SCHEMA,
         "experiment_id": experiment_id,
@@ -248,7 +752,9 @@ def _enforce_as_of(workflow: str, as_of: str, report: Mapping[str, Any]) -> None
             "price-action observation timestamp",
         )
         if timestamp > cutoff:
-            raise ValueError("price-action experiment includes observations after experiment as_of")
+            raise ValueError(
+                "price-action experiment includes observations after experiment as_of"
+            )
 
 
 def _parse_timestamp(value: Any, label: str) -> datetime:
@@ -270,3 +776,23 @@ def _file_digest(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _validate_output_target(output_dir: str | Path) -> Path:
+    target = Path(output_dir)
+    if target.exists():
+        if not target.is_dir():
+            raise ValueError("experiment output path must be a directory")
+        if next(target.iterdir(), None) is not None:
+            raise ValueError("experiment output directory must be empty")
+    return target
+
+
+def _write_new_json(path: Path, value: Any) -> None:
+    try:
+        with path.open("x", encoding="utf-8") as handle:
+            handle.write(json.dumps(value, indent=2, sort_keys=True) + "\n")
+    except FileExistsError as exc:
+        raise ValueError(
+            f"experiment output artifact already exists: {path.name}"
+        ) from exc

--- a/tests/test_experiment_manifest.py
+++ b/tests/test_experiment_manifest.py
@@ -1,13 +1,93 @@
+import copy
+import hashlib
+import io
 import json
 import tempfile
 import unittest
+from argparse import Namespace
+from contextlib import redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
-from gex_terminal.experiment_manifest import reproduce_experiment, run_experiment
+from gex_terminal.cli import experiment_reproduce_command
+from gex_terminal.experiment_manifest import (
+    EXPERIMENT_CANONICALIZATION,
+    EXPERIMENT_EVIDENCE_CEILING,
+    EXPERIMENT_EVIDENCE_POLICY,
+    EXPERIMENT_IDENTITY_SCHEMA,
+    EXPERIMENT_MANIFEST_SCHEMA_V1,
+    EXPERIMENT_MANIFEST_SCHEMA_V2,
+    EXPERIMENT_RUNTIME_CONTRACT,
+    canonical_sha256,
+    reproduce_experiment,
+    run_experiment,
+    semantic_sha256,
+)
 from gex_terminal.package_data import provider_fixture_path
+from gex_terminal.price_action_validation import load_price_action_report
 
 
 class ExperimentManifestTests(unittest.IsolatedAsyncioTestCase):
+    async def _run_example(self, root: Path) -> tuple[dict, Path]:
+        spec = json.loads(provider_fixture_path("experiment_spec_example.json").read_text())
+        spec["input"] = str(provider_fixture_path("price_action_validation_example.json"))
+        spec_path = root / "spec.json"
+        spec_path.write_text(json.dumps(spec), encoding="utf-8")
+        manifest = await run_experiment(spec_path, root / "first")
+        return manifest, root / "first" / "manifest.json"
+
+    @staticmethod
+    def _write_manifest(root: Path, name: str, manifest: dict) -> Path:
+        target = root / name
+        target.write_text(json.dumps(manifest), encoding="utf-8")
+        return target
+
+    @staticmethod
+    def _legacy_v1_manifest(v2: dict, *, version: str = "0.4.0") -> dict:
+        return {
+            "schema": EXPERIMENT_MANIFEST_SCHEMA_V1,
+            "experiment_id": v2["experiment_id"],
+            "generated_at": v2["generated_at"],
+            "workflow": v2["workflow"],
+            "implementation": {
+                "package": "gex-terminal",
+                "version": version,
+                "python": v2["implementation"]["python"],
+            },
+            "spec_reference": v2["spec_reference"],
+            "source_root": v2["source_root"],
+            "experiment_spec": copy.deepcopy(v2["experiment_spec"]),
+            "profile_sha256": semantic_sha256(v2["experiment_spec"]["model_profile"]),
+            "input": copy.deepcopy(v2["input"]),
+            "result": copy.deepcopy(v2["result"]),
+            "reproduction": {
+                "expected_semantic_sha256": None,
+                "matched": True,
+            },
+            "evidence_ceiling": EXPERIMENT_EVIDENCE_CEILING,
+        }
+
+    @staticmethod
+    def _refresh_experiment_sha256(manifest: dict) -> None:
+        identity = manifest["identity"]
+        identity["experiment_sha256"] = canonical_sha256({
+            "schema": EXPERIMENT_IDENTITY_SCHEMA,
+            "canonicalization": EXPERIMENT_CANONICALIZATION,
+            "manifest_schema": EXPERIMENT_MANIFEST_SCHEMA_V2,
+            "profile_sha256": identity["profile_sha256"],
+            "experiment_spec_sha256": identity["experiment_spec_sha256"],
+            "input": {
+                "sha256": manifest["input"]["sha256"],
+                "bytes": manifest["input"]["bytes"],
+            },
+            "implementation": manifest["implementation"],
+            "result": {
+                "semantic_sha256": manifest["result"]["semantic_sha256"],
+                "predictive_validity": "unmeasured",
+            },
+            "evidence_policy": EXPERIMENT_EVIDENCE_POLICY,
+        })
+
     async def test_enforces_as_of_against_price_action_observations(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -33,18 +113,357 @@ class ExperimentManifestTests(unittest.IsolatedAsyncioTestCase):
     async def test_run_and_reproduce_match_semantically(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
-            spec = json.loads(provider_fixture_path("experiment_spec_example.json").read_text())
-            input_path = provider_fixture_path("price_action_validation_example.json")
-            spec["input"] = str(input_path)
-            spec_path = root / "spec.json"
-            spec_path.write_text(json.dumps(spec), encoding="utf-8")
-            first = await run_experiment(spec_path, root / "first")
+            first, manifest_path = await self._run_example(root)
             second = await reproduce_experiment(root / "first" / "manifest.json", root / "second")
+            self.assertEqual(first["schema"], EXPERIMENT_MANIFEST_SCHEMA_V2)
+            self.assertEqual(first["identity"]["schema"], EXPERIMENT_IDENTITY_SCHEMA)
+            self.assertEqual(
+                first["identity"]["canonicalization"], EXPERIMENT_CANONICALIZATION
+            )
+            self.assertEqual(
+                first["implementation"]["runtime_contract"],
+                EXPERIMENT_RUNTIME_CONTRACT,
+            )
             self.assertTrue(second["reproduction"]["matched"])
+            self.assertEqual(second["reproduction"]["identity_validation"], "complete")
+            self.assertEqual(
+                second["reproduction"]["source_manifest_schema"],
+                EXPERIMENT_MANIFEST_SCHEMA_V2,
+            )
+            self.assertEqual(
+                second["reproduction"]["source_manifest_sha256"],
+                hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+            )
             self.assertEqual(
                 first["result"]["semantic_sha256"], second["result"]["semantic_sha256"]
             )
+            self.assertEqual(
+                first["identity"]["experiment_sha256"],
+                second["identity"]["experiment_sha256"],
+            )
             self.assertEqual(first["result"]["predictive_validity"], "unmeasured")
+
+    async def test_v2_rejects_profile_and_complete_spec_relabeling_before_execution(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            first, _ = await self._run_example(root)
+            cases = (
+                (
+                    "profile",
+                    lambda manifest: manifest["experiment_spec"]["model_profile"].__setitem__(
+                        "profile_id", "relabeled-profile"
+                    ),
+                    "profile identity",
+                ),
+                (
+                    "split",
+                    lambda manifest: manifest["experiment_spec"].__setitem__("split", "train"),
+                    "spec identity",
+                ),
+                (
+                    "outcome",
+                    lambda manifest: manifest["experiment_spec"].__setitem__(
+                        "outcome_definition", "relabeled outcome"
+                    ),
+                    "spec identity",
+                ),
+                (
+                    "costs",
+                    lambda manifest: manifest["experiment_spec"].__setitem__(
+                        "cost_assumptions", {"fees": "zero"}
+                    ),
+                    "spec identity",
+                ),
+                (
+                    "as-of",
+                    lambda manifest: manifest["experiment_spec"].__setitem__(
+                        "as_of", "2026-08-07T16:00:00Z"
+                    ),
+                    "spec identity",
+                ),
+                (
+                    "predictive-validity",
+                    lambda manifest: manifest["experiment_spec"].__setitem__(
+                        "predictive_validity", "validated"
+                    ),
+                    "predictive_validity must be unmeasured",
+                ),
+            )
+            for name, mutate, message in cases:
+                with self.subTest(name=name):
+                    manifest = copy.deepcopy(first)
+                    mutate(manifest)
+                    manifest_path = self._write_manifest(root, f"{name}.json", manifest)
+                    output = root / f"{name}-output"
+                    with patch(
+                        "gex_terminal.experiment_manifest.load_price_action_report"
+                    ) as workflow:
+                        with self.assertRaisesRegex(ValueError, message):
+                            await reproduce_experiment(manifest_path, output)
+                    workflow.assert_not_called()
+                    self.assertFalse(output.exists())
+
+    async def test_v2_rejects_unknown_contract_fields_before_execution(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            first, _ = await self._run_example(root)
+            cases = (
+                (
+                    "manifest",
+                    lambda manifest: manifest.__setitem__("extension", "ignored"),
+                    "experiment manifest contains unsupported fields",
+                ),
+                (
+                    "spec",
+                    lambda manifest: manifest["experiment_spec"].__setitem__(
+                        "extension", "ignored"
+                    ),
+                    "experiment spec contains unsupported fields",
+                ),
+                (
+                    "profile",
+                    lambda manifest: manifest["experiment_spec"][
+                        "model_profile"
+                    ].__setitem__("extension", "ignored"),
+                    "experiment model_profile contains unsupported fields",
+                ),
+                (
+                    "implementation",
+                    lambda manifest: manifest["implementation"].__setitem__(
+                        "extension", "ignored"
+                    ),
+                    "experiment implementation contains unsupported fields",
+                ),
+                (
+                    "identity",
+                    lambda manifest: manifest["identity"].__setitem__(
+                        "extension", "ignored"
+                    ),
+                    "experiment identity contains unsupported fields",
+                ),
+            )
+            for name, mutate, message in cases:
+                with self.subTest(name=name):
+                    manifest = copy.deepcopy(first)
+                    mutate(manifest)
+                    manifest_path = self._write_manifest(
+                        root, f"unknown-{name}.json", manifest
+                    )
+                    output = root / f"unknown-{name}-output"
+                    with patch(
+                        "gex_terminal.experiment_manifest.load_price_action_report"
+                    ) as workflow:
+                        with self.assertRaisesRegex(ValueError, message):
+                            await reproduce_experiment(manifest_path, output)
+                    workflow.assert_not_called()
+                    self.assertFalse(output.exists())
+
+    async def test_reproduction_refuses_nonempty_output_without_overwrite(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _, manifest_path = await self._run_example(root)
+            report_path = root / "first" / "report.json"
+            original_manifest = manifest_path.read_bytes()
+            original_report = report_path.read_bytes()
+
+            with patch(
+                "gex_terminal.experiment_manifest.load_price_action_report"
+            ) as workflow:
+                with self.assertRaisesRegex(ValueError, "output directory must be empty"):
+                    await reproduce_experiment(manifest_path, root / "first")
+
+            workflow.assert_not_called()
+            self.assertEqual(manifest_path.read_bytes(), original_manifest)
+            self.assertEqual(report_path.read_bytes(), original_report)
+
+    async def test_v2_rejects_mirror_identity_and_implementation_changes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            first, _ = await self._run_example(root)
+            cases = (
+                (
+                    "experiment-id",
+                    lambda manifest: manifest.__setitem__("experiment_id", "other"),
+                    "experiment_id does not match",
+                ),
+                (
+                    "input-reference",
+                    lambda manifest: manifest["input"].__setitem__("reference", "other.json"),
+                    "input reference does not match",
+                ),
+                (
+                    "workflow",
+                    lambda manifest: manifest.__setitem__("workflow", "databento_replay"),
+                    "workflow does not match",
+                ),
+                (
+                    "identity",
+                    lambda manifest: manifest["identity"].__setitem__(
+                        "experiment_sha256", "0" * 64
+                    ),
+                    "identity does not match",
+                ),
+                (
+                    "producer",
+                    lambda manifest: manifest["implementation"].__setitem__(
+                        "version", "9.9.9"
+                    ),
+                    "unsupported experiment producer version",
+                ),
+                (
+                    "runtime",
+                    lambda manifest: manifest["implementation"].__setitem__(
+                        "runtime_contract", "gex-terminal.experiment-runtime.v999"
+                    ),
+                    "unsupported experiment runtime contract",
+                ),
+            )
+            for name, mutate, message in cases:
+                with self.subTest(name=name):
+                    manifest = copy.deepcopy(first)
+                    mutate(manifest)
+                    manifest_path = self._write_manifest(root, f"{name}.json", manifest)
+                    output = root / f"{name}-output"
+                    with self.assertRaisesRegex(ValueError, message):
+                        await reproduce_experiment(manifest_path, output)
+                    self.assertFalse(output.exists())
+
+    async def test_v2_rejects_result_drift_without_writing_output(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _, manifest_path = await self._run_example(root)
+            changed_report = load_price_action_report(
+                provider_fixture_path("price_action_validation_example.json")
+            )
+            changed_report["dataset"]["label"] = "changed-after-recording"
+            output = root / "drift-output"
+            with patch(
+                "gex_terminal.experiment_manifest.load_price_action_report",
+                return_value=changed_report,
+            ):
+                with self.assertRaisesRegex(ValueError, "semantic result"):
+                    await reproduce_experiment(manifest_path, output)
+            self.assertFalse(output.exists())
+
+    async def test_v2_rejects_source_byte_count_drift_after_identity_validation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            first, _ = await self._run_example(root)
+            changed = copy.deepcopy(first)
+            changed["input"]["bytes"] += 1
+            self._refresh_experiment_sha256(changed)
+            manifest_path = self._write_manifest(root, "wrong-size.json", changed)
+            output = root / "wrong-size-output"
+            with patch(
+                "gex_terminal.experiment_manifest.load_price_action_report"
+            ) as workflow:
+                with self.assertRaisesRegex(ValueError, "input byte count changed"):
+                    await reproduce_experiment(manifest_path, output)
+            workflow.assert_not_called()
+            self.assertFalse(output.exists())
+
+    async def test_v1_known_producers_reproduce_with_partial_identity_lineage(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            first, _ = await self._run_example(root)
+            for version in ("0.3.0", "0.4.0"):
+                with self.subTest(version=version):
+                    legacy = self._legacy_v1_manifest(first, version=version)
+                    manifest_path = self._write_manifest(
+                        root, f"legacy-{version}.json", legacy
+                    )
+                    source_sha256 = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+                    reproduced = await reproduce_experiment(
+                        manifest_path, root / f"legacy-{version}-output"
+                    )
+                    self.assertEqual(reproduced["schema"], EXPERIMENT_MANIFEST_SCHEMA_V2)
+                    self.assertTrue(reproduced["reproduction"]["matched"])
+                    self.assertEqual(
+                        reproduced["reproduction"]["identity_validation"],
+                        "legacy_partial",
+                    )
+                    self.assertEqual(
+                        reproduced["reproduction"]["source_manifest_sha256"],
+                        source_sha256,
+                    )
+                    self.assertEqual(
+                        reproduced["reproduction"]["implementation_compatibility"][
+                            "recorded_version"
+                        ],
+                        version,
+                    )
+
+    async def test_cli_exposes_legacy_partial_identity_status(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            first, _ = await self._run_example(root)
+            legacy = self._legacy_v1_manifest(first)
+            manifest_path = self._write_manifest(root, "legacy-cli.json", legacy)
+            output = io.StringIO()
+            with redirect_stdout(output):
+                await experiment_reproduce_command(Namespace(
+                    command_path=str(manifest_path),
+                    command_args=[str(root / "legacy-cli-output")],
+                ))
+            self.assertIn("matched=True", output.getvalue())
+            self.assertIn("identity_validation=legacy_partial", output.getvalue())
+
+    async def test_v1_rejects_stale_profile_hash_and_unknown_producer(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            first, _ = await self._run_example(root)
+
+            stale = self._legacy_v1_manifest(first)
+            stale["experiment_spec"]["model_profile"]["profile_id"] = "relabeled"
+            stale_path = self._write_manifest(root, "legacy-stale.json", stale)
+            with self.assertRaisesRegex(ValueError, "profile identity"):
+                await reproduce_experiment(stale_path, root / "stale-output")
+
+            unknown = self._legacy_v1_manifest(first, version="0.2.0")
+            unknown_path = self._write_manifest(root, "legacy-unknown.json", unknown)
+            with self.assertRaisesRegex(ValueError, "unsupported experiment producer version"):
+                await reproduce_experiment(unknown_path, root / "unknown-output")
+
+    async def test_rejects_unknown_schema_malformed_digest_and_nonfinite_json(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            first, _ = await self._run_example(root)
+
+            unknown = copy.deepcopy(first)
+            unknown["schema"] = "gex-terminal.experiment-manifest.v999"
+            unknown_path = self._write_manifest(root, "unknown-schema.json", unknown)
+            with self.assertRaisesRegex(ValueError, "unsupported experiment manifest schema"):
+                await reproduce_experiment(unknown_path, root / "unknown-schema-output")
+
+            malformed = copy.deepcopy(first)
+            malformed["identity"]["profile_sha256"] = "not-a-digest"
+            malformed_path = self._write_manifest(root, "malformed-hash.json", malformed)
+            with self.assertRaisesRegex(ValueError, "lowercase SHA-256"):
+                await reproduce_experiment(malformed_path, root / "malformed-output")
+
+            spec = json.loads(provider_fixture_path("experiment_spec_example.json").read_text())
+            spec["input"] = str(provider_fixture_path("price_action_validation_example.json"))
+            spec["cost_assumptions"] = {"fees": float("nan")}
+            nonfinite_path = root / "nonfinite-spec.json"
+            nonfinite_path.write_text(json.dumps(spec), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "non-finite JSON value"):
+                await run_experiment(nonfinite_path, root / "nonfinite-output")
+
+            duplicate_path = root / "duplicate-manifest.json"
+            duplicate_path.write_text(
+                '{"schema":"gex-terminal.experiment-manifest.v2",'
+                '"schema":"gex-terminal.experiment-manifest.v2"}',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "duplicate JSON key"):
+                await reproduce_experiment(duplicate_path, root / "duplicate-output")
+
+    def test_canonical_identity_hashes_every_field(self):
+        first = {"generated_at": "one", "value": 1}
+        second = {"generated_at": "two", "value": 1}
+        self.assertNotEqual(canonical_sha256(first), canonical_sha256(second))
+        self.assertEqual(semantic_sha256(first), semantic_sha256(second))
+        self.assertEqual(EXPERIMENT_EVIDENCE_POLICY, "gex-terminal.offline-evidence-ceiling.v1")
 
     async def test_reproduction_rejects_changed_input_digest(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Outcome

Close the remaining P1 correctness finding: reproduction now verifies complete
experiment identity, including metadata that does not alter the numeric result.

## Scope

- Integrates the isolated contributor branch without rewriting its history.
- Versioned v2 identities bind spec, profile, input, implementation and result.
- Unknown/inconsistent identities fail before execution; v1 stays explicitly
  partial. Existing nonempty output directories cannot be overwritten.
- Updates the canonical repair packet and roadmap/status links.

## Evidence

344 tests passed, source compilation and diff checks passed. Tamper, legacy,
unknown-version and no-overwrite regressions included. Hosted Python 3.11/3.12
and installed-wheel checks required before merge.

No live data, provider readiness, predictive validity or authenticity claim.
