### PR TITLE
Close 0.5.0 release and harden terminal shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ Release is claimed.
 
 ### Fixed
 
+- Terminal refresh callbacks now belong to the dashboard screen and revalidate
+  ownership after asynchronous work, preventing render/cache publication after
+  shutdown, quit or screen replacement. Resize remains dashboard-bound behind
+  overlays. Six deterministic regressions raise the full suite to 425 tests;
+  genuine mounted rendering errors remain visible.
 - Compact terminal rendering at 140×42 and above, clear guidance below the
   supported minimum, and state-preserving resize coverage.
 - Experiment v2 manifests now bind complete specification, profile, input,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Release is claimed.
 
 ### Changed
 
+- Accepted offline engineering through PR #25 after independent review, four
+  hosted checks and 419 tests on clean merged main. Closed contributor packets
+  while keeping customer activation, rights and live observations open.
 - Reprioritized the roadmap around application correctness, offline preflight,
   reuse of existing research packs, and one usable installation path; corrected
   phase dependencies and separated commercial and empirical research tracks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,8 @@ changes before implementation, name a work packet for L2/L3 work, preserve its
 baseline and evidence ceiling, and close technical shipment separately from
 external outcome validation. Use a `codex/` feature branch, focused named-file
 commits, a pull request, hosted checks, merge, and a clean post-merge test for a
-release slice. The closed
+release slice. The closed [GEX-OFFLINE-001 packet](docs/work-packets/GEX-OFFLINE-001.md)
+records the `0.5.0` offline product integration and release evidence. The closed
 [GEX-LIVE-001 packet](docs/work-packets/GEX-LIVE-001.md) records that complete
 workflow for the `0.4.0` pre-live hardening slice. The earlier
 [GEX-ORC-001 packet](docs/work-packets/GEX-ORC-001.md) remains a structural

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ status checklists into multiple files.
 
 An active work packet under `work-packets/` owns the status of its authorized
 change. Closed packets are historical evidence and do not make a roadmap item
-active. [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) owns the
+active. Closed [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) owns the
 offline release record; the closed preflight, support, installation and
 research-loop packets own their contributor evidence. `GEX-HEALTH-001` through `005` record
 merged correctness repairs. [GEX-LIVE-002](work-packets/GEX-LIVE-002.md) is
@@ -104,7 +104,7 @@ offline live-population contract that supports that later external gate.
 - [GEX-LIVE-001](work-packets/GEX-LIVE-001.md) — closed `0.4.0` pre-live
   hardening and release record; credentialed validation remains external
   follow-on work.
-- [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) — `0.5.0` offline
+- [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) — closed `0.5.0` offline
   product integration, verification and release record.
 - [GEX-LIVE-PREP-001](work-packets/GEX-LIVE-PREP-001.md) — closed offline
   preregistration and result-manifest contract; no live execution is authorized.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,9 +33,9 @@ status checklists into multiple files.
 
 An active work packet under `work-packets/` owns the status of its authorized
 change. Closed packets are historical evidence and do not make a roadmap item
-active. [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) owns offline release
-integration; the individual preflight, support, installation and research-loop
-packets own their contributor evidence. `GEX-HEALTH-001` through `005` record
+active. Closed [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) owns the accepted
+offline release record; the closed preflight, support, installation and
+research-loop packets own their contributor evidence. `GEX-HEALTH-001` through `005` record
 merged correctness repairs. [GEX-LIVE-002](work-packets/GEX-LIVE-002.md) is
 prepared only; it grants no live execution authority.
 [GEX-LIVE-PREP-001](work-packets/GEX-LIVE-PREP-001.md) owns only the bounded
@@ -104,7 +104,9 @@ offline live-population contract that supports that later external gate.
 - [GEX-LIVE-001](work-packets/GEX-LIVE-001.md) — closed `0.4.0` pre-live
   hardening and release record; credentialed validation remains external
   follow-on work.
-- [GEX-LIVE-PREP-001](work-packets/GEX-LIVE-PREP-001.md) — active offline
+- [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) — closed `0.5.0` offline
+  product integration, verification and release record.
+- [GEX-LIVE-PREP-001](work-packets/GEX-LIVE-PREP-001.md) — closed offline
   preregistration and result-manifest contract; no live execution is authorized.
 
 ## Editing Rules

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ status checklists into multiple files.
 
 An active work packet under `work-packets/` owns the status of its authorized
 change. Closed packets are historical evidence and do not make a roadmap item
-active. Closed [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) owns the accepted
+active. [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) owns the
 offline release record; the closed preflight, support, installation and
 research-loop packets own their contributor evidence. `GEX-HEALTH-001` through `005` record
 merged correctness repairs. [GEX-LIVE-002](work-packets/GEX-LIVE-002.md) is
@@ -104,7 +104,7 @@ offline live-population contract that supports that later external gate.
 - [GEX-LIVE-001](work-packets/GEX-LIVE-001.md) — closed `0.4.0` pre-live
   hardening and release record; credentialed validation remains external
   follow-on work.
-- [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) — closed `0.5.0` offline
+- [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) — `0.5.0` offline
   product integration, verification and release record.
 - [GEX-LIVE-PREP-001](work-packets/GEX-LIVE-PREP-001.md) — closed offline
   preregistration and result-manifest contract; no live execution is authorized.

--- a/docs/SAED_ADOPTION_PROFILE.md
+++ b/docs/SAED_ADOPTION_PROFILE.md
@@ -19,11 +19,11 @@
 **Adopted:** 2026-08-19
 
 **Status owner:** Each routed contributor packet owns its bounded slice;
-`GEX-OFFLINE-001` owns the `0.5.0` integration and release. `GEX-HEALTH-001`
+closed `GEX-OFFLINE-001` owns the `0.5.0` integration and release record. `GEX-HEALTH-001`
 through `005` record merged repairs. Closed `GEX-LIVE-001` records `0.4.0`;
 prepared `GEX-LIVE-002` does not authorize or certify live operation.
-Active `GEX-LIVE-PREP-001` owns only offline population preparation for that
-future observation.
+Closed `GEX-LIVE-PREP-001` owns only offline population preparation for that
+future observation. No repository-owned offline implementation packet remains active.
 
 ## Purpose And Entry Boundary
 
@@ -160,3 +160,4 @@ predeclared outcomes, untouched test data, costs, and an observation window.
 | --- | --- | --- | --- | --- | --- |
 | 2026-08-19 | none | `gex-terminal-team-v1` | Initial SAED 1.3 adoption | `GEX-ORC-001` | Adopted for multi-participant release workflow |
 | 2026-08-31 | `GEX-ORC-001` closed | `GEX-LIVE-001` closed | Shipped repository-owned pre-live certification hardening for `0.4.0`; credentialed outcome remains external | none | Contributor and closeout pull requests, merged-tree gate, and annotated tag completed |
+| 2026-09-04 | Correctness and offline product slices | `GEX-OFFLINE-001` closed | Accepted correctness, doctor, portable loop, compact installation, support/recovery and offline live-population preparation for `0.5.0` | none; `GEX-LIVE-002` prepared only | Independent contributor review, hosted checks and verified main; user/live evidence remains external |

--- a/docs/SAED_ADOPTION_PROFILE.md
+++ b/docs/SAED_ADOPTION_PROFILE.md
@@ -19,11 +19,12 @@
 **Adopted:** 2026-08-19
 
 **Status owner:** Each routed contributor packet owns its bounded slice;
-closed `GEX-OFFLINE-001` owns the `0.5.0` integration and release record. `GEX-HEALTH-001`
+active `GEX-OFFLINE-001` owns the `0.5.0` integration and release record. `GEX-HEALTH-001`
 through `005` record merged repairs. Closed `GEX-LIVE-001` records `0.4.0`;
 prepared `GEX-LIVE-002` does not authorize or certify live operation.
 Closed `GEX-LIVE-PREP-001` owns only offline population preparation for that
-future observation. No repository-owned offline implementation packet remains active.
+future observation. `GEX-HEALTH-006` and reopened `GEX-INSTALL-001` cover the
+release-blocking terminal shutdown regression found by the final hosted gate.
 
 ## Purpose And Entry Boundary
 

--- a/docs/SAED_ADOPTION_PROFILE.md
+++ b/docs/SAED_ADOPTION_PROFILE.md
@@ -19,12 +19,13 @@
 **Adopted:** 2026-08-19
 
 **Status owner:** Each routed contributor packet owns its bounded slice;
-active `GEX-OFFLINE-001` owns the `0.5.0` integration and release record. `GEX-HEALTH-001`
+closed `GEX-OFFLINE-001` owns the `0.5.0` integration and release record. `GEX-HEALTH-001`
 through `005` record merged repairs. Closed `GEX-LIVE-001` records `0.4.0`;
 prepared `GEX-LIVE-002` does not authorize or certify live operation.
 Closed `GEX-LIVE-PREP-001` owns only offline population preparation for that
-future observation. `GEX-HEALTH-006` and reopened `GEX-INSTALL-001` cover the
-release-blocking terminal shutdown regression found by the final hosted gate.
+future observation. Closed `GEX-HEALTH-006` and `GEX-INSTALL-001` also record the
+terminal shutdown regression and repair found by the final hosted gate. No
+repository-owned offline implementation packet remains active.
 
 ## Purpose And Entry Boundary
 

--- a/docs/application-review.md
+++ b/docs/application-review.md
@@ -9,9 +9,9 @@ document owns the dated state assessment and verification limits.
 
 The application is an offline research alpha with corrected result identity,
 fail-closed configuration, isolated replay replacement and verifiable portable
-research packs. All five P1 correctness repairs are merged. Compact-terminal
-support and the offline product foundation are undergoing final integrated
-release verification under [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md).
+research packs. All five P1 correctness repairs, compact-terminal support and
+the offline product foundation are accepted. The release evidence and remaining
+external gates are recorded in [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md).
 
 No credentialed provider observation, real-user activation study, customer
 commitment or commercial pilot was performed. Databento remains
@@ -46,7 +46,7 @@ packets rather than being duplicated here.
 | H3 — Replay writer contamination | Resolved: cancel and await prior writer before reset; full interactive CLI regressions for fixed/event clocks and failure | [GEX-HEALTH-003](work-packets/GEX-HEALTH-003.md) |
 | H4 — Experiment metadata relabeling | Resolved: complete v2 identity before reproduction; legacy partial status; reject unknown/inconsistent fields and nonempty targets | [GEX-HEALTH-004](work-packets/GEX-HEALTH-004.md) |
 | H5 — Rejected-input chronology | Resolved: analytical points follow accepted updates; raw input audit separated; snapshot/model time agree | [GEX-HEALTH-005](work-packets/GEX-HEALTH-005.md) |
-| H6 — Clipped small terminal | Implemented: visibility checks at supported sizes, explicit minimum message below them and state-preserving resize | [GEX-INSTALL-001](work-packets/GEX-INSTALL-001.md) |
+| H6 — Clipped small terminal | Resolved: visibility checks at supported sizes, explicit minimum message below them and state-preserving resize | [GEX-INSTALL-001](work-packets/GEX-INSTALL-001.md) |
 
 These are scoped regression results, not a claim that the application has no
 other defects. Source and tests were inspected together; runtime boundaries
@@ -86,11 +86,14 @@ Package dependency downloads are not market-data connections.
 | Cross-version pack | Actual 0.4.0 contributor receipt verified/reproduced under 0.5.0 with matching source/model/content | Same Python 3.12 and NumPy/Textual runtime; original tagged 0.4.0 legacy packs are not upgraded |
 | Doctor contribution | 52 focused / 335 branch tests, distributions/Twine, isolated normal/invalid/missing-base checks | Branch baseline differs; final integrated total below |
 | Compact terminal | Screenshots inspected at 140×42 and 80×24; visibility/resize regressions passed | Not a user study |
-| Integrated release branch | 419 tests, compilation and 202 local documentation links passed; numerical, property, offline-provider, fault and 500-contract performance gates passed | Offline implementation evidence only; hosted/merged-main closeout pending |
+| Integrated release | PR #25 merged as `830d6a7`; clean pulled main passed 419 tests, compilation and 206 documentation links; numerical, property, offline-provider, fault and 500-contract performance gates passed | Offline implementation evidence only |
 | Distribution lifecycle | Complete feature wheel passed build/Twine and 0.4.0 → 0.5.0 install/upgrade/corrupt-update/rollback/uninstall; all 14 research-file byte identities preserved | macOS ARM64/Python 3.12.13; no arbitrary interrupted-install guarantee |
+| Hosted release checks | All four PR #25 Python 3.11/3.12 Linux checks passed, including full tests, fresh-wheel commands and recovery lifecycle | Hosted software verification, not live operation |
+| Independent installed wheel | Full command matrix passed in a fresh Python 3.14.4 environment; NQ identities, redacted support and private backup/restore verified | Additional command smoke only; full-suite baseline remains 3.11/3.12 |
 
-The complete final release gate and clean merged-tree evidence must be recorded
-before tagging. Follow [Contributing](../CONTRIBUTING.md) for repeatable commands,
+The release closeout and annotated tag identify the final verified merged tree;
+[GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md) records acceptance without
+promoting the external gates. Follow [Contributing](../CONTRIBUTING.md) for repeatable commands,
 [First Run](first-run.md) for installation, and the individual guides for
 artifact contracts. Run review commands in new scratch directories so existing
 research cannot be overwritten. No dependency vulnerability audit or external

--- a/docs/application-review.md
+++ b/docs/application-review.md
@@ -10,7 +10,10 @@ document owns the dated state assessment and verification limits.
 The application is an offline research alpha with corrected result identity,
 fail-closed configuration, isolated replay replacement and verifiable portable
 research packs. All five P1 correctness repairs, compact-terminal support and
-the offline product foundation are accepted. The release evidence and remaining
+the offline product foundation passed their integration checks. The final
+closeout gate then exposed a terminal shutdown race: an in-flight refresh can
+access removed widgets. Release/tagging is paused for the `GEX-HEALTH-006`
+repair and renewed verification. The release evidence and remaining
 external gates are recorded in [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md).
 
 No credentialed provider observation, real-user activation study, customer

--- a/docs/application-review.md
+++ b/docs/application-review.md
@@ -10,10 +10,9 @@ document owns the dated state assessment and verification limits.
 The application is an offline research alpha with corrected result identity,
 fail-closed configuration, isolated replay replacement and verifiable portable
 research packs. All five P1 correctness repairs, compact-terminal support and
-the offline product foundation passed their integration checks. The final
-closeout gate then exposed a terminal shutdown race: an in-flight refresh can
-access removed widgets. Release/tagging is paused for the `GEX-HEALTH-006`
-repair and renewed verification. The release evidence and remaining
+the offline product foundation are accepted. Final hosted verification exposed
+a terminal shutdown race, now corrected through `GEX-HEALTH-006` with six
+deterministic lifecycle regressions and 425 passing tests. The release evidence and remaining
 external gates are recorded in [GEX-OFFLINE-001](work-packets/GEX-OFFLINE-001.md).
 
 No credentialed provider observation, real-user activation study, customer
@@ -50,6 +49,7 @@ packets rather than being duplicated here.
 | H4 — Experiment metadata relabeling | Resolved: complete v2 identity before reproduction; legacy partial status; reject unknown/inconsistent fields and nonempty targets | [GEX-HEALTH-004](work-packets/GEX-HEALTH-004.md) |
 | H5 — Rejected-input chronology | Resolved: analytical points follow accepted updates; raw input audit separated; snapshot/model time agree | [GEX-HEALTH-005](work-packets/GEX-HEALTH-005.md) |
 | H6 — Clipped small terminal | Resolved: visibility checks at supported sizes, explicit minimum message below them and state-preserving resize | [GEX-INSTALL-001](work-packets/GEX-INSTALL-001.md) |
+| H7 — Refresh after screen teardown | Resolved: screen-owned callbacks, exact-owner checks after both awaits, no cache/UI publication after quit/teardown; resize remains owner-bound behind overlays | [GEX-HEALTH-006](work-packets/GEX-HEALTH-006.md) |
 
 These are scoped regression results, not a claim that the application has no
 other defects. Source and tests were inspected together; runtime boundaries
@@ -92,6 +92,7 @@ Package dependency downloads are not market-data connections.
 | Integrated release | PR #25 merged as `830d6a7`; clean pulled main passed 419 tests, compilation and 206 documentation links; numerical, property, offline-provider, fault and 500-contract performance gates passed | Offline implementation evidence only |
 | Distribution lifecycle | Complete feature wheel passed build/Twine and 0.4.0 → 0.5.0 install/upgrade/corrupt-update/rollback/uninstall; all 14 research-file byte identities preserved | macOS ARM64/Python 3.12.13; no arbitrary interrupted-install guarantee |
 | Hosted release checks | All four PR #25 Python 3.11/3.12 Linux checks passed, including full tests, fresh-wheel commands and recovery lifecycle | Hosted software verification, not live operation |
+| Final lifecycle repair | PR #26 initially exposed the shutdown race on 3.12; 3.11 was fail-fast-cancelled. Independently reviewed repair and root integration each passed 425 tests | Initial green checkpoints do not erase the observed failure; final tag requires repaired-tree hosted/package checks |
 | Independent installed wheel | Full command matrix passed in a fresh Python 3.14.4 environment; NQ identities, redacted support and private backup/restore verified | Additional command smoke only; full-suite baseline remains 3.11/3.12 |
 
 The release closeout and annotated tag identify the final verified merged tree;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,13 @@ and controls, with scrolling for explanatory cards. Below the declared minimum,
 an explicit message replaces the clipped dashboard; resizing restores it
 without resetting market state. The large layout exposes the additional sidebar.
 
+The dashboard screen owns its periodic and initial refresh callbacks. Refresh
+work captures that owner and checks it again after snapshot and expiry awaits;
+quit, teardown or another current screen prevents cache/UI publication. Resize
+updates the captured dashboard even behind an overlay. Genuine render errors
+on the current mounted dashboard still propagate; replay-writer ownership is
+a separate boundary.
+
 ## Live Provider Flow
 
 ```text

--- a/docs/work-packets/GEX-HEALTH-006.md
+++ b/docs/work-packets/GEX-HEALTH-006.md
@@ -1,0 +1,71 @@
+# GEX-HEALTH-006 — TUI Refresh Teardown Ownership
+
+```yaml
+method: saed
+method_version: "1.3"
+profile: gex-terminal-team-v1
+change_rigor: L3
+status: active
+packet_owner: project maintainer
+spec_steward: implementation agent
+evidence_reviewer: pull-request reviewer and hosted CI
+baseline: codex/gex-050-release-record@dcb75ea
+branch: codex/gex-health-006
+created: 2026-09-04
+```
+
+## Observed failure and authority
+
+PR #26 pull-request CI run `33923631319` failed in its Linux Python 3.12 test
+job while its branch checks passed. The Python 3.11 matrix job was cancelled by
+fail-fast during its installed-wheel step; it did not independently reproduce
+the defect. In Python 3.12, a periodic `refresh_terminal_data` call was still
+awaiting the consumer when the Textual test app began teardown. It then resumed
+after the application screen's widgets had been pruned, and `_render_lifecycle`
+raised `NoMatches` while querying `#feed-websocket`. The three observed errors
+reached Demo Lab pack generation and the first-run assumption-controls test;
+they are one asynchronous lifecycle race, not evidence that those workflows
+have independent model defects.
+
+The maintainer authorized a bounded lifecycle-ownership repair in the TUI and
+deterministic regressions. This packet does not authorize model, consumer,
+replay-writer, provider, artifact, documentation-index, version, release, live
+data, credential, or readiness changes.
+
+## Invariants
+
+- `H6-01` — The periodic refresh timer and initial deferred refresh belong to
+  the mounted application screen, whose message-pump closure stops them before
+  its widgets are detached.
+- `H6-02` — A refresh that crosses an await boundary may render only when the
+  same mounted application screen still owns the widgets it began with.
+  Teardown or screen replacement invalidates that render without
+  relabeling the consumer result as displayed.
+- `H6-03` — Exceptions raised by consumer work or by rendering into a still
+  current mounted screen remain visible. Do not catch `NoMatches` broadly, add
+  a blind delay/retry, or suppress unrelated render defects.
+- `H6-04` — Manual refresh, periodic refresh, terminal resize, replay switching,
+  and assumption changes keep their current behavior while mounted.
+- `H6-05` — The H3 replay source-task transition remains separately owned:
+  teardown must not cancel, replace, or hide failures from `_source_task`.
+
+## Acceptance
+
+1. A deterministic test pauses consumer snapshot work, begins a refresh, exits
+   or unmounts the test application, then releases the pause. The refresh must
+   finish without querying widgets from the detached/default screen and without
+   leaking an asynchronous exception.
+2. A mounted-screen test proves an unexpected render exception still
+   propagates; the repair is lifecycle-aware, not blanket exception handling.
+3. Existing replay-ownership and first-run controls continue to pass, including
+   source-task failure visibility and replacement ordering.
+4. The focused TUI, Demo Lab, terminal-size, screenshot, and replay-ownership
+   tests pass. The full suite and compilation pass on the isolated branch.
+
+## Evidence ceiling and recovery
+
+Passing evidence establishes deterministic local Textual lifecycle ownership
+for the tested refresh boundaries. It does not establish every terminal/runtime
+scheduler interleaving, live-provider operation, customer usability, or release
+acceptance. Recovery is a reviewed revert of this packet's TUI/test change; no
+stored research, provider state, or user data is migrated or deleted.

--- a/docs/work-packets/GEX-HEALTH-006.md
+++ b/docs/work-packets/GEX-HEALTH-006.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: ready for contributor review
+status: closed
 packet_owner: project maintainer
 spec_steward: implementation agent
 evidence_reviewer: pull-request reviewer and hosted CI
@@ -93,3 +93,9 @@ stored research, provider state, or user data is migrated or deleted.
   `gex_terminal`, `tests`, and `scripts` passed, and `git diff --check` passed.
 - No provider, replay-source task, model, data artifact, live-data, credential,
   packaging, version, or release behavior changed in this branch.
+
+Independent review cleared commit `6519755` with no remaining P1/P2 and repeated
+the full 425-test suite successfully. Root integration `d7de7b8` also passed
+425 tests, compilation and documentation links. Accepted under
+[GEX-OFFLINE-001](GEX-OFFLINE-001.md); final rebuilt-package and hosted checks
+remain mandatory before the annotated release tag.

--- a/docs/work-packets/GEX-HEALTH-006.md
+++ b/docs/work-packets/GEX-HEALTH-006.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: active
+status: ready for contributor review
 packet_owner: project maintainer
 spec_steward: implementation agent
 evidence_reviewer: pull-request reviewer and hosted CI
@@ -69,3 +69,27 @@ for the tested refresh boundaries. It does not establish every terminal/runtime
 scheduler interleaving, live-provider operation, customer usability, or release
 acceptance. Recovery is a reviewed revert of this packet's TUI/test change; no
 stored research, provider state, or user data is migrated or deleted.
+
+## Implementation and verification evidence
+
+- A disposable baseline harness against `dcb75ea` deterministically reproduced
+  both vulnerable await boundaries: teardown during snapshot work raised
+  `NoMatches` for `#feed-websocket`, and teardown during expiry-breakdown work
+  raised `NoMatches` for `#stat-spot`. The harness was not retained in the
+  branch.
+- The default dashboard screen now owns the periodic timer and initial deferred
+  refresh. Refreshes retain that screen identity across awaits and publish
+  cache/UI state only while the same owner remains current, mounted, and
+  running. Explicit application exit also invalidates publication.
+- Resize events update the captured dashboard screen directly, including while
+  a command-palette or other pushed screen is current, without querying the
+  foreign screen. Returning to the dashboard preserves the updated compact or
+  minimum-size state.
+- Six deterministic lifecycle regressions passed, including timer cancellation,
+  snapshot and breakdown teardown, explicit exit, screen replacement/return,
+  owner-bound resize, and propagation of a genuine mounted-screen `NoMatches`.
+- The focused related set passed 46 tests. The complete test suite passed 425
+  tests with the repository virtual environment on Python 3.12. Compilation of
+  `gex_terminal`, `tests`, and `scripts` passed, and `git diff --check` passed.
+- No provider, replay-source task, model, data artifact, live-data, credential,
+  packaging, version, or release behavior changed in this branch.

--- a/docs/work-packets/GEX-HEALTH-006.md
+++ b/docs/work-packets/GEX-HEALTH-006.md
@@ -99,3 +99,10 @@ the full 425-test suite successfully. Root integration `d7de7b8` also passed
 425 tests, compilation and documentation links. Accepted under
 [GEX-OFFLINE-001](GEX-OFFLINE-001.md); final rebuilt-package and hosted checks
 remain mandatory before the annotated release tag.
+
+The first hosted repair run (`33925106300`) then caught a test-harness defect:
+wrapping the async context exit in `asyncio.wait_for` moved it into another
+Task, invalidating Textual ContextVar reset tokens. The harness now uses
+`asyncio.timeout` around a same-task exit, preserving the deadline and the
+original teardown assertions. This adjustment changes no application code and
+does not suppress the original regression or relax its acceptance criteria.

--- a/docs/work-packets/GEX-INSTALL-001.md
+++ b/docs/work-packets/GEX-INSTALL-001.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: active
+status: closed
 packet_owner: project maintainer
 branch: codex/gex-install-001-guided-terminal
 created: 2026-09-04
@@ -54,5 +54,8 @@ identities. Source and wheel distributions passed build/Twine. A regular wheel
 replaced the locally broken editable launcher, and version/doctor succeeded.
 Independent review added wheel digests/version ordering, working-app checks
 after failed upgrade and complete metadata/launcher absence after uninstall.
-The exact final build and hosted lifecycle still require verification before
-closure. A corrupt-wheel test is not arbitrary interrupted-upgrade recovery.
+The complete feature wheel then passed that final lifecycle locally; all four
+PR #25 Linux Python 3.11/3.12 hosted checks also passed it. Clean merged main
+`830d6a7` passed 419 tests. [GEX-OFFLINE-001](GEX-OFFLINE-001.md) owns the final
+release record. A corrupt-wheel test is not arbitrary interrupted-upgrade
+recovery, and real-user activation remains unmeasured.

--- a/docs/work-packets/GEX-INSTALL-001.md
+++ b/docs/work-packets/GEX-INSTALL-001.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: active
+status: closed
 packet_owner: project maintainer
 branch: codex/gex-install-001-guided-terminal
 created: 2026-09-04
@@ -61,5 +61,7 @@ release record. A corrupt-wheel test is not arbitrary interrupted-upgrade
 recovery, and real-user activation remains unmeasured.
 
 Reopened at the PR #26 release gate after hosted tests exposed an in-flight
-refresh accessing removed terminal widgets. `GEX-HEALTH-006` routes the bounded
-repair; final distribution evidence must be refreshed before closure.
+refresh accessing removed terminal widgets. The independently reviewed
+[GEX-HEALTH-006](GEX-HEALTH-006.md) repair then passed all 425 integrated tests;
+the release process rebuilds distributions and reruns hosted/clean-main gates
+before tagging. The pre-repair candidate is not the released artifact.

--- a/docs/work-packets/GEX-INSTALL-001.md
+++ b/docs/work-packets/GEX-INSTALL-001.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: closed
+status: active
 packet_owner: project maintainer
 branch: codex/gex-install-001-guided-terminal
 created: 2026-09-04
@@ -59,3 +59,7 @@ PR #25 Linux Python 3.11/3.12 hosted checks also passed it. Clean merged main
 `830d6a7` passed 419 tests. [GEX-OFFLINE-001](GEX-OFFLINE-001.md) owns the final
 release record. A corrupt-wheel test is not arbitrary interrupted-upgrade
 recovery, and real-user activation remains unmeasured.
+
+Reopened at the PR #26 release gate after hosted tests exposed an in-flight
+refresh accessing removed terminal widgets. `GEX-HEALTH-006` routes the bounded
+repair; final distribution evidence must be refreshed before closure.

--- a/docs/work-packets/GEX-LIVE-PREP-001.md
+++ b/docs/work-packets/GEX-LIVE-PREP-001.md
@@ -6,7 +6,7 @@ method_version: "1.3"
 profile: gex-terminal-team-v1
 adoption_context: team
 change_rigor: L3
-status: ready for contributor review; final combined gate pending support guide
+status: closed
 packet_owner: project maintainer
 spec_steward: implementation agent
 evidence_reviewer: pull-request reviewer and hosted CI
@@ -141,11 +141,15 @@ modify plan/result files, migrate user data, or contact an external system.
   new packaged template missing from the doctor resource inventory and the five
   already-declared links to the support owner's not-yet-integrated
   `docs/local-support.md`. The resource inventory was repaired and its focused
-  regression passed. The remaining documentation-link failure belongs to the
-  pending support integration, so this packet does **not** claim a clean full
-  repository pass; the maintainer will run that combined gate after both
-  contributor slices land.
+  regression passed. The support integration subsequently resolved the remaining
+  documentation failure. PR #25 passed all four hosted checks, and clean merged
+  main `830d6a7` passed all 419 tests and 206 documentation links. The final
+  installed wheel rejected the unapproved template as required.
 - No provider adapter, credential lookup, scheduler, capture writer, or network
   execution path was added. No live observation, customer evidence, report-byte
   authentication, predictive result, provider-readiness change, or promotion is
   claimed.
+
+Accepted offline implementation is closed under
+[GEX-OFFLINE-001](GEX-OFFLINE-001.md). The separate `GEX-LIVE-002` packet remains
+prepared and does not grant execution authority.

--- a/docs/work-packets/GEX-OFFLINE-001.md
+++ b/docs/work-packets/GEX-OFFLINE-001.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: active
+status: closed
 packet_owner: project maintainer
 branch: codex/gex-offline-product-closeout
 created: 2026-09-04
@@ -71,7 +71,38 @@ research migration is introduced by this release.
   Destructive tests used disposable synthetic groups only, with verified
   recovery copies. No actual user research or credentials were deleted.
 
-Final fresh-wheel command review, hosted checks and clean merged-main release
-closeout remain required before the annotated tag. Preparation documents are
-deliverables, not evidence that external customer, licensing or live-operation
-gates have passed.
+## Accepted integration and release record
+
+- [PR #25](https://github.com/zrack/gex-terminal/pull/25) merged as
+  `830d6a7eddbec74001abe8f59b5bcecbc7631ba5` after all four hosted checks passed.
+  Linux Python 3.11/3.12 each passed tests, wheel commands and the full
+  installation/recovery lifecycle on both branch and pull-request checks.
+- Clean pulled main at that merge passed all 419 tests, compilation, patch
+  hygiene and 206 local documentation links. The earlier support-guide/resource
+  integration failures are resolved; they are not outstanding release defects.
+- An independent fresh Python 3.14.4 environment also passed the complete
+  installed-wheel command matrix with filtered environment and isolated import,
+  including doctor, NQ verify/reproduce, support, private backup/restore,
+  experiments, corpus and all offline gates. The unapproved population template
+  failed as required. This additional command smoke does not extend the declared
+  Python 3.11/3.12 full-suite support baseline.
+- NQ reproduction preserved source, profile and semantic identities; restore
+  preserved the original receipt and all content. Private directories/files
+  were `0700`/`0600`; redacted support output contained no selected local path.
+  An actual 0.4.0 contributor receipt also verified/reproduced under 0.5.0 with
+  matching identities on its supported runtime; legacy packs from the original
+  tagged 0.4.0 release are not silently upgraded to this receipt contract.
+  Independent application, safety and documentation review found no remaining
+  P1/P2 findings in this scope.
+- This documentation closeout follows the same checked PR and clean-main
+  verification cycle; its local gate passed 419 tests, compilation and all 215
+  documentation links. Release identity is the annotated `v0.5.0` tag on that
+  verified closeout tree; no existing tag is moved and no PyPI/hosted Release
+  publication is included. Git and hosted checks own final ref/run identities.
+
+All authorized repository-owned offline implementation is accepted. The next
+work is [Roadmap](../../ROADMAP.md#current-work-order) observed first use,
+customer/rights/economics decisions and separately authorized ES observations.
+Preparation is not evidence those external gates passed. `GEX-LIVE-002` remains
+prepared with execution authority false; Databento remains `live-uncertified`
+and predictive validity remains `unmeasured`.

--- a/docs/work-packets/GEX-OFFLINE-001.md
+++ b/docs/work-packets/GEX-OFFLINE-001.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: active
+status: closed
 packet_owner: project maintainer
 branch: codex/gex-offline-product-closeout
 created: 2026-09-04
@@ -73,16 +73,19 @@ research migration is introduced by this release.
 
 ## Accepted integration and release record
 
-### Release-blocking amendment
+### Resolved release-blocking amendment
 
 The PR #26 closeout gate exposed a terminal refresh/teardown race in hosted run
 `33923631319`: an in-flight timer attempted to render after dashboard widgets
 were removed. The Python 3.12 test job failed; the 3.11 job was cancelled during
-wheel checks by matrix fail-fast, while branch checks passed. The release and
-tag are paused; `GEX-HEALTH-006` owns a deterministic
-regression and bounded lifecycle repair. Earlier passing evidence remains a
-checkpoint, not final release acceptance. Rebuild and revalidate distributions
-after the repair; do not reuse the pre-repair wheel as the released artifact.
+wheel checks by matrix fail-fast, while branch checks passed. Release/tagging
+paused and the pre-repair candidate was set aside. The independently reviewed
+[GEX-HEALTH-006](GEX-HEALTH-006.md) repair landed in integration `d7de7b8`;
+all 425 tests, compilation and 215 links passed. Deterministic old-code failures
+at both await boundaries now pass without suppressing genuine render errors.
+Final distribution and hosted gates must use the repaired tree, not the
+superseded candidate. Git checks and the annotated release tag identify that
+verified final tree.
 
 - [PR #25](https://github.com/zrack/gex-terminal/pull/25) merged as
   `830d6a7eddbec74001abe8f59b5bcecbc7631ba5` after all four hosted checks passed.
@@ -105,16 +108,16 @@ after the repair; do not reuse the pre-repair wheel as the released artifact.
   tagged 0.4.0 release are not silently upgraded to this receipt contract.
   Independent application, safety and documentation review found no remaining
   P1/P2 findings in this scope.
-- This documentation closeout follows the same checked PR and clean-main
-  verification cycle; its local gate passed 419 tests, compilation and all 215
+- This closeout follows the same checked PR and clean-main verification cycle;
+  its local gate passed 425 tests after the shutdown repair, compilation and
   documentation links. Release identity is established by the annotated
   `v0.5.0` tag only after this closeout passes its PR and clean-main verification
   cycle; no existing tag is moved and no PyPI/hosted Release
   publication is included. Git and hosted checks own final ref/run identities.
 
-All previously scoped offline implementation is accepted; the newly observed
-terminal shutdown defect must close before release. The subsequent product work is
-work is [Roadmap](../../ROADMAP.md#current-work-order) observed first use,
+All authorized offline implementation and the observed shutdown repair are
+accepted. The subsequent product work is
+[Roadmap](../../ROADMAP.md#current-work-order) observed first use,
 customer/rights/economics decisions and separately authorized ES observations.
 Preparation is not evidence those external gates passed. `GEX-LIVE-002` remains
 prepared with execution authority false; Databento remains `live-uncertified`

--- a/docs/work-packets/GEX-OFFLINE-001.md
+++ b/docs/work-packets/GEX-OFFLINE-001.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: closed
+status: active
 packet_owner: project maintainer
 branch: codex/gex-offline-product-closeout
 created: 2026-09-04
@@ -73,6 +73,16 @@ research migration is introduced by this release.
 
 ## Accepted integration and release record
 
+### Release-blocking amendment
+
+The PR #26 closeout gate exposed a terminal refresh/teardown race in hosted run
+`33923631319`: an in-flight timer attempted to render after dashboard widgets
+were removed. Both pull-request Python jobs failed even though branch checks
+passed. The release and tag are paused; `GEX-HEALTH-006` owns a deterministic
+regression and bounded lifecycle repair. Earlier passing evidence remains a
+checkpoint, not final release acceptance. Rebuild and revalidate distributions
+after the repair; do not reuse the pre-repair wheel as the released artifact.
+
 - [PR #25](https://github.com/zrack/gex-terminal/pull/25) merged as
   `830d6a7eddbec74001abe8f59b5bcecbc7631ba5` after all four hosted checks passed.
   Linux Python 3.11/3.12 each passed tests, wheel commands and the full
@@ -101,7 +111,8 @@ research migration is introduced by this release.
   cycle; no existing tag is moved and no PyPI/hosted Release
   publication is included. Git and hosted checks own final ref/run identities.
 
-All authorized repository-owned offline implementation is accepted. The next
+All previously scoped offline implementation is accepted; the newly observed
+terminal shutdown defect must close before release. The subsequent product work is
 work is [Roadmap](../../ROADMAP.md#current-work-order) observed first use,
 customer/rights/economics decisions and separately authorized ES observations.
 Preparation is not evidence those external gates passed. `GEX-LIVE-002` remains

--- a/docs/work-packets/GEX-OFFLINE-001.md
+++ b/docs/work-packets/GEX-OFFLINE-001.md
@@ -96,8 +96,9 @@ research migration is introduced by this release.
   P1/P2 findings in this scope.
 - This documentation closeout follows the same checked PR and clean-main
   verification cycle; its local gate passed 419 tests, compilation and all 215
-  documentation links. Release identity is the annotated `v0.5.0` tag on that
-  verified closeout tree; no existing tag is moved and no PyPI/hosted Release
+  documentation links. Release identity is established by the annotated
+  `v0.5.0` tag only after this closeout passes its PR and clean-main verification
+  cycle; no existing tag is moved and no PyPI/hosted Release
   publication is included. Git and hosted checks own final ref/run identities.
 
 All authorized repository-owned offline implementation is accepted. The next

--- a/docs/work-packets/GEX-OFFLINE-001.md
+++ b/docs/work-packets/GEX-OFFLINE-001.md
@@ -77,8 +77,9 @@ research migration is introduced by this release.
 
 The PR #26 closeout gate exposed a terminal refresh/teardown race in hosted run
 `33923631319`: an in-flight timer attempted to render after dashboard widgets
-were removed. Both pull-request Python jobs failed even though branch checks
-passed. The release and tag are paused; `GEX-HEALTH-006` owns a deterministic
+were removed. The Python 3.12 test job failed; the 3.11 job was cancelled during
+wheel checks by matrix fail-fast, while branch checks passed. The release and
+tag are paused; `GEX-HEALTH-006` owns a deterministic
 regression and bounded lifecycle repair. Earlier passing evidence remains a
 checkpoint, not final release acceptance. Rebuild and revalidate distributions
 after the repair; do not reuse the pre-repair wheel as the released artifact.

--- a/docs/work-packets/GEX-PREFLIGHT-001.md
+++ b/docs/work-packets/GEX-PREFLIGHT-001.md
@@ -6,7 +6,7 @@ method_version: "1.3"
 profile: gex-terminal-team-v1
 adoption_context: team
 change_rigor: L3
-status: Ready for integration — contributor evidence passed
+status: closed
 packet_owner: project maintainer
 spec_steward: implementation agent
 architecture_authority: project maintainer
@@ -202,3 +202,8 @@ None.
 A successful doctor proves only the reported local preflight facts; it cannot
 prove provider access, market-data quality, live reliability, or predictive
 validity.
+
+Accepted in PR #25 with four passing hosted checks and 419 tests on clean
+merged main `830d6a7`. The final resource inventory contains 31 resources after
+NQ and live-plan preparation integration. Fresh installed-wheel doctor passed;
+[GEX-OFFLINE-001](GEX-OFFLINE-001.md) owns the combined release evidence.

--- a/docs/work-packets/GEX-RESEARCH-LOOP-001.md
+++ b/docs/work-packets/GEX-RESEARCH-LOOP-001.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: ready for contributor review
+status: closed
 packet_owner: project maintainer
 spec_steward: implementation agent
 evidence_reviewer: pull-request reviewer and hosted CI
@@ -129,5 +129,8 @@ overwrite a reproduction target.
   reproduced it, and verified the reproduction. Source, model-profile, and all
   five decision-content hashes matched; a path scan found no checkout or source
   archive absolute path.
-- Hosted checks and independent contributor review remain merge gates and are
-  not claimed by this packet.
+- Accepted in PR #25 after independent review and four passing hosted checks.
+  Clean merged main `830d6a7` passed 419 tests; the final installed wheel passed
+  NQ verification/reproduction and backup/restore with preserved identities.
+  [GEX-OFFLINE-001](GEX-OFFLINE-001.md) owns combined release evidence, including
+  the separately verified 0.4.0-contributor to 0.5.0 compatibility boundary.

--- a/docs/work-packets/GEX-SUPPORT-001.md
+++ b/docs/work-packets/GEX-SUPPORT-001.md
@@ -5,7 +5,7 @@ method: saed
 method_version: "1.3"
 profile: gex-terminal-team-v1
 change_rigor: L3
-status: ready_for_integration
+status: closed
 packet_owner: project maintainer
 spec_steward: implementation agent
 evidence_reviewer: pull-request reviewer and hosted CI
@@ -133,3 +133,9 @@ operate on non-synthetic user data during implementation.
 - No provider credentials, live data, user research, licensed capture store,
   package uninstall, authenticity claim, or deletion outside disposable
   temporary directories was exercised.
+
+Accepted in PR #25 after independent safety review found no remaining P1/P2,
+four hosted checks passed and clean merged main `830d6a7` passed 419 tests.
+The final wheel independently passed redacted support, private backup,
+verification and restore; identities and owner-only modes matched.
+[GEX-OFFLINE-001](GEX-OFFLINE-001.md) owns the combined release record.

--- a/gex_terminal/tui.py
+++ b/gex_terminal/tui.py
@@ -11,6 +11,8 @@ from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.containers import Container, Grid, Vertical
 from textual.events import Resize
+from textual.screen import Screen
+from textual.timer import Timer
 from textual.widgets import DataTable, Footer, Header, Sparkline, Static
 
 from gex_terminal.config import GexConfig
@@ -94,6 +96,8 @@ class GexTerminalApp(App):
         self._replay_index = self._initial_replay_index()
         self._replay_browser_open = False
         self._replay_browser_index = self._initial_browser_index()
+        self._refresh_screen_owner: Screen | None = None
+        self._refresh_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -182,21 +186,36 @@ class GexTerminalApp(App):
         self._render_controls()
         self._render_first_run_guide(self.consumer.runtime_status)
         self._render_status_bar(self.consumer.runtime_status)
-        self.set_interval(self.config.refresh_interval_seconds, self.refresh_terminal_data)
-        self.call_later(self.refresh_terminal_data)
+        screen = self.screen
+        self._refresh_screen_owner = screen
+        self._refresh_timer = screen.set_interval(
+            self.config.refresh_interval_seconds,
+            self.refresh_terminal_data,
+        )
+        screen.call_later(self.refresh_terminal_data)
         self._apply_terminal_size()
 
     def on_resize(self, event: Resize) -> None:
-        if self.is_mounted:
+        screen = self._refresh_screen_owner
+        if (
+            self.is_running
+            and not self._exit
+            and screen is not None
+            and screen.is_running
+            and screen.is_mounted
+        ):
             self._apply_terminal_size((event.size.width, event.size.height))
 
     def _apply_terminal_size(self, size: tuple[int, int] | None = None) -> None:
         width, height = size or self.size
         minimum_width, minimum_height = self.MINIMUM_TERMINAL_SIZE
         supported = width >= minimum_width and height >= minimum_height
-        self.screen.set_class(width < 180 or height < 54, "compact")
-        self.query_one("#dashboard").display = supported
-        message = self.query_one("#minimum-size-message", Static)
+        screen = self._refresh_screen_owner
+        if screen is None:
+            return
+        screen.set_class(width < 180 or height < 54, "compact")
+        screen.query_one("#dashboard").display = supported
+        message = screen.query_one("#minimum-size-message", Static)
         message.display = not supported
         message.update(
             f"Terminal needs at least {minimum_width} × {minimum_height} cells.\n"
@@ -625,28 +644,46 @@ class GexTerminalApp(App):
 
     async def refresh_terminal_data(self) -> None:
         """Poll the consumer and render the latest GEX matrix."""
+        refresh_screen = self._refresh_screen()
+        if refresh_screen is None:
+            return
+
         started = time.perf_counter()
         data = await self.consumer.process_latest_snapshot(
             days_to_expiry=self.config.days_to_expiry,
             expiry_filter=self.config.expiry_filter,
         )
-        self._last_latency_ms = (time.perf_counter() - started) * 1000
-        self._latencies.append(self._last_latency_ms)
-        self._last_refresh_at = self._timestamp()
-        self._render_lifecycle()
-        status = self.consumer.runtime_status
-        self._render_status_bar(status)
-        self._render_quality()
+        latency_ms = (time.perf_counter() - started) * 1000
+        if not self._refresh_screen_is_current(refresh_screen):
+            return
 
         if "error" in data:
+            self._last_latency_ms = latency_ms
+            self._latencies.append(latency_ms)
+            self._last_refresh_at = self._timestamp()
             self._last_data = None
+            status = self.consumer.runtime_status
+            self._render_lifecycle()
+            self._render_status_bar(status)
+            self._render_quality()
             self._render_empty_state(data["error"], status)
             return
 
-        self._last_data = data
-        self._last_breakdown = await self.consumer.process_expiry_breakdown(
+        breakdown = await self.consumer.process_expiry_breakdown(
             days_to_expiry=self.config.days_to_expiry
         )
+        if not self._refresh_screen_is_current(refresh_screen):
+            return
+
+        self._last_latency_ms = latency_ms
+        self._latencies.append(latency_ms)
+        self._last_refresh_at = self._timestamp()
+        self._last_data = data
+        self._last_breakdown = breakdown
+        status = self.consumer.runtime_status
+        self._render_lifecycle()
+        self._render_status_bar(status)
+        self._render_quality()
         self._gex_flow.append(float(data["total_net_gex"]))
         self._record_events(data)
         self._render_metrics(data)
@@ -659,6 +696,26 @@ class GexTerminalApp(App):
         self._render_state_banner(status)
         if self._replay_browser_open:
             self._render_replay_browser()
+
+    def _refresh_screen(self) -> Screen | None:
+        """Return the mounted screen that currently owns refresh rendering."""
+        if not self.is_running or self._exit:
+            return None
+        screen = self._refresh_screen_owner
+        if screen is None or not screen.is_running or not screen.is_mounted:
+            return None
+        return screen if self.screen is screen else None
+
+    def _refresh_screen_is_current(self, screen: Screen) -> bool:
+        """Check refresh ownership after an await without touching a closed stack."""
+        return (
+            self.is_running
+            and not self._exit
+            and self._refresh_screen_owner is screen
+            and screen.is_running
+            and screen.is_mounted
+            and self.screen is screen
+        )
 
     def _render_empty_state(self, reason: str, status: str) -> None:
         self.query_one("#gex-table", DataTable).clear()

--- a/tests/test_tui_lifecycle.py
+++ b/tests/test_tui_lifecycle.py
@@ -90,7 +90,10 @@ class TuiRefreshLifecycleTests(unittest.IsolatedAsyncioTestCase):
         await asyncio.wait_for(consumer.stage_started.wait(), 2)
         screen = app.screen
 
-        await asyncio.wait_for(context.__aexit__(None, None, None), 2)
+        # Preserve the ContextVar tokens established by __aenter__: wait_for
+        # would run __aexit__ in a different Task/context on supported Pythons.
+        async with asyncio.timeout(2):
+            await context.__aexit__(None, None, None)
 
         self.assertTrue(consumer.stage_cancelled.is_set())
         self.assertFalse(app.is_running)
@@ -208,7 +211,8 @@ class TuiRefreshLifecycleTests(unittest.IsolatedAsyncioTestCase):
                 await asyncio.wait_for(consumer.stage_started.wait(), 2)
                 screen = app.screen
 
-                await asyncio.wait_for(context.__aexit__(None, None, None), 2)
+                async with asyncio.timeout(2):
+                    await context.__aexit__(None, None, None)
                 self.assertFalse(app.is_running)
                 self.assertFalse(screen.is_running)
                 consumer.release_stage.set()

--- a/tests/test_tui_lifecycle.py
+++ b/tests/test_tui_lifecycle.py
@@ -1,0 +1,244 @@
+import asyncio
+import unittest
+
+from textual.css.query import NoMatches
+from textual.screen import Screen
+
+from gex_terminal.cli import seed_demo_session
+from gex_terminal.config import GexConfig
+from gex_terminal.consumer import StatefulGexConsumer
+from gex_terminal.engine import IntradayGexEngine
+from gex_terminal.tui import GexTerminalApp
+
+
+def _config(refresh_interval_seconds: float = 3600.0) -> GexConfig:
+    return GexConfig(
+        symbol="ES",
+        symbols=("ES", "NQ"),
+        data_mode="demo",
+        data_provider="tradovate",
+        contract_multiplier=50,
+        risk_free_rate=0.045,
+        days_to_expiry=0.01,
+        refresh_interval_seconds=refresh_interval_seconds,
+        stale_after_seconds=10.0,
+        replay_path="sample_data/demo_replay.jsonl",
+        replay_delay_seconds=0.0,
+        tradovate_environment="demo",
+    )
+
+
+class ControlledRefreshConsumer(StatefulGexConsumer):
+    def __init__(self) -> None:
+        super().__init__(IntradayGexEngine(), data_mode="demo")
+        self.initial_snapshot_complete = asyncio.Event()
+        self.block_stage: str | None = None
+        self.stage_started = asyncio.Event()
+        self.release_stage = asyncio.Event()
+        self.stage_cancelled = asyncio.Event()
+        self.snapshot_call_count = 0
+
+    def block_next(self, stage: str) -> None:
+        if stage not in {"snapshot", "breakdown"}:
+            raise ValueError(f"unsupported refresh stage: {stage}")
+        self.block_stage = stage
+        self.stage_started = asyncio.Event()
+        self.release_stage = asyncio.Event()
+        self.stage_cancelled = asyncio.Event()
+
+    async def _block_if_selected(self, stage: str) -> None:
+        if self.block_stage != stage:
+            return
+        self.block_stage = None
+        self.stage_started.set()
+        try:
+            await self.release_stage.wait()
+        except asyncio.CancelledError:
+            self.stage_cancelled.set()
+            raise
+
+    async def process_latest_snapshot(self, *args, **kwargs):
+        self.snapshot_call_count += 1
+        await self._block_if_selected("snapshot")
+        result = await super().process_latest_snapshot(*args, **kwargs)
+        self.initial_snapshot_complete.set()
+        return result
+
+    async def process_expiry_breakdown(self, *args, **kwargs):
+        await self._block_if_selected("breakdown")
+        return await super().process_expiry_breakdown(*args, **kwargs)
+
+
+class TuiRefreshLifecycleTests(unittest.IsolatedAsyncioTestCase):
+    async def _ready_app(self, *, interval: float = 3600.0):
+        consumer = ControlledRefreshConsumer()
+        await seed_demo_session(consumer)
+        app = GexTerminalApp(consumer, _config(interval))
+        context = app.run_test(size=(160, 48))
+        pilot = await context.__aenter__()
+        await asyncio.wait_for(consumer.initial_snapshot_complete.wait(), 2)
+        await pilot.pause()
+        return consumer, app, context, pilot
+
+    async def test_screen_owns_interval_and_cancels_inflight_refresh_before_detach(self):
+        consumer, app, context, _pilot = await self._ready_app(interval=0.1)
+        timer = app._refresh_timer
+        self.assertIsNotNone(timer)
+        self.assertIs(timer.target, app.screen)
+
+        consumer.block_next("snapshot")
+        await asyncio.wait_for(consumer.stage_started.wait(), 2)
+        screen = app.screen
+
+        await asyncio.wait_for(context.__aexit__(None, None, None), 2)
+
+        self.assertTrue(consumer.stage_cancelled.is_set())
+        self.assertFalse(app.is_running)
+        self.assertFalse(screen.is_running)
+        self.assertIsNone(timer._task)
+        self.assertIsNone(app._exception)
+
+    async def test_refresh_stays_bound_to_dashboard_across_screen_replacement(self):
+        consumer, app, context, pilot = await self._ready_app()
+        try:
+            app._refresh_timer.pause()
+            owner = app._refresh_screen_owner
+            self.assertIs(owner, app.screen)
+            baseline = (app._last_data, app._last_breakdown, tuple(app._gex_flow))
+
+            consumer.block_next("snapshot")
+            refresh = asyncio.create_task(app.refresh_terminal_data())
+            await asyncio.wait_for(consumer.stage_started.wait(), 2)
+            await app.push_screen(Screen())
+            await pilot.pause()
+            self.assertIsNot(app.screen, owner)
+
+            consumer.release_stage.set()
+            await asyncio.wait_for(refresh, 2)
+            self.assertEqual(
+                (app._last_data, app._last_breakdown, tuple(app._gex_flow)),
+                baseline,
+            )
+
+            calls = consumer.snapshot_call_count
+            await app.refresh_terminal_data()
+            self.assertEqual(consumer.snapshot_call_count, calls)
+
+            app.pop_screen()
+            await pilot.pause()
+            self.assertIs(app.screen, owner)
+            await app.refresh_terminal_data()
+            self.assertEqual(consumer.snapshot_call_count, calls + 1)
+        finally:
+            await context.__aexit__(None, None, None)
+
+    async def test_resize_updates_dashboard_owner_behind_pushed_screen(self):
+        _consumer, app, context, pilot = await self._ready_app()
+        try:
+            app._refresh_timer.pause()
+            owner = app._refresh_screen_owner
+            await app.push_screen(Screen())
+            await pilot.pause()
+            overlay = app.screen
+
+            await pilot.resize_terminal(80, 24)
+            await pilot.pause()
+            self.assertFalse(overlay.has_class("compact"))
+            self.assertTrue(owner.query_one("#minimum-size-message").display)
+            self.assertFalse(owner.query_one("#dashboard").display)
+
+            app.pop_screen()
+            await pilot.pause()
+            self.assertIs(app.screen, owner)
+            self.assertTrue(owner.query_one("#minimum-size-message").display)
+            self.assertFalse(owner.query_one("#dashboard").display)
+
+            await pilot.resize_terminal(160, 48)
+            await pilot.pause()
+            self.assertFalse(owner.query_one("#minimum-size-message").display)
+            self.assertTrue(owner.query_one("#dashboard").display)
+        finally:
+            await context.__aexit__(None, None, None)
+
+    async def test_quit_invalidates_inflight_refresh_before_publication(self):
+        consumer, app, context, _pilot = await self._ready_app()
+        try:
+            app._refresh_timer.pause()
+            baseline = (
+                app._last_data,
+                app._last_breakdown,
+                app._last_refresh_at,
+                tuple(app._gex_flow),
+            )
+            consumer.block_next("breakdown")
+            refresh = asyncio.create_task(app.refresh_terminal_data())
+            await asyncio.wait_for(consumer.stage_started.wait(), 2)
+
+            app.exit()
+            consumer.release_stage.set()
+            await asyncio.wait_for(refresh, 2)
+
+            self.assertEqual(
+                (
+                    app._last_data,
+                    app._last_breakdown,
+                    app._last_refresh_at,
+                    tuple(app._gex_flow),
+                ),
+                baseline,
+            )
+        finally:
+            await context.__aexit__(None, None, None)
+
+    async def test_inflight_manual_refresh_does_not_publish_after_teardown(self):
+        for stage in ("snapshot", "breakdown"):
+            with self.subTest(stage=stage):
+                consumer, app, context, _pilot = await self._ready_app()
+                app._refresh_timer.pause()
+                baseline = (
+                    app._last_data,
+                    app._last_breakdown,
+                    app._last_latency_ms,
+                    tuple(app._latencies),
+                    app._last_refresh_at,
+                    tuple(app._gex_flow),
+                )
+                consumer.block_next(stage)
+                refresh = asyncio.create_task(app.refresh_terminal_data())
+                await asyncio.wait_for(consumer.stage_started.wait(), 2)
+                screen = app.screen
+
+                await asyncio.wait_for(context.__aexit__(None, None, None), 2)
+                self.assertFalse(app.is_running)
+                self.assertFalse(screen.is_running)
+                consumer.release_stage.set()
+                await asyncio.wait_for(refresh, 2)
+
+                self.assertEqual(
+                    (
+                        app._last_data,
+                        app._last_breakdown,
+                        app._last_latency_ms,
+                        tuple(app._latencies),
+                        app._last_refresh_at,
+                        tuple(app._gex_flow),
+                    ),
+                    baseline,
+                )
+                self.assertIsNone(app._exception)
+
+    async def test_missing_required_widget_still_raises_while_screen_is_current(self):
+        _consumer, app, context, pilot = await self._ready_app()
+        try:
+            app._refresh_timer.pause()
+            await pilot.pause()
+            await app.query_one("#feed-websocket").remove()
+
+            with self.assertRaises(NoMatches):
+                await app.refresh_terminal_data()
+        finally:
+            await context.__aexit__(None, None, None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Record acceptance of the offline 0.5.0 foundation after feature PR #25 merged as 830d6a7. Close the offline packets, refresh health/ownership records, repair the terminal shutdown race discovered by this PR's first hosted gate, and preserve external user, rights and live-data gates.

## Evidence

- Feature PR #25: all four hosted Python 3.11/3.12 checks passed, including wheel commands and install/recovery lifecycle.
- Clean feature main: 419 tests, compilation, patch hygiene and 206 local documentation links passed.
- This PR's first Python 3.12 hosted run exposed three terminal teardown errors; 3.11 was cancelled by matrix fail-fast. The release was paused and the pre-fix package was set aside.
- HEALTH-006 reproduced the old errors deterministically at both await boundaries. Dashboard-owned callbacks, post-await ownership checks and owner-bound resize now pass six new lifecycle regressions without hiding genuine rendering errors or changing replay-source ownership.
- Independent contributor and root integration each passed all 425 tests; compilation, patch hygiene and 219 current links pass.
- Independent complete-wheel command matrix, NQ reproduction, redacted support and private backup/restore passed. Independent application/safety/documentation review cleared the feature scope.
- The only added application repair in this closeout is terminal lifecycle ownership. No provider, model, credential, live-data, real-user-data deletion, PyPI publication or hosted Release change.

## Final sequence

Require this PR's hosted checks, merge without squashing contributor history, cleanly pull and verify main, build final local distributions, then annotate/push v0.5.0. Existing v0.4.0 is unchanged. GEX-LIVE-002 remains prepared with execution authority false. Git tags and hosted checks own final ref/run identities.
